### PR TITLE
feat(domain): scaffold domain layer — entities, repos, use cases, Result type (T-7–T-11)

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,0 +1,36 @@
+# Makefile
+# Convenience targets for Variance development.
+# CI and local quality gates.
+
+.PHONY: domain-check analyze format test
+
+# ---------------------------------------------------------------------------
+# T-11: Domain purity gate
+# Verifies that lib/domain/ has zero Flutter imports and zero analyzer errors.
+# Fails the build if any `package:flutter` import is found in the domain layer.
+# ---------------------------------------------------------------------------
+domain-check:
+	@echo "--- Checking domain layer for Flutter imports ---"
+	@if grep -r "package:flutter" lib/domain/ \
+	    --include="*.dart" \
+	    --exclude="*.freezed.dart" \
+	    --exclude="*.g.dart"; then \
+	  echo "ERROR: Flutter import(s) found in lib/domain/ — domain must be pure Dart."; \
+	  exit 1; \
+	fi
+	@echo "OK: No Flutter imports in lib/domain/"
+	@echo "--- Running dart analyze on lib/domain/ ---"
+	flutter analyze lib/domain/
+	@echo "Domain purity check passed."
+
+# ---------------------------------------------------------------------------
+# General targets
+# ---------------------------------------------------------------------------
+analyze:
+	flutter analyze lib/
+
+format:
+	dart format lib/ test/
+
+test:
+	flutter test

--- a/lib/domain/core/failure.dart
+++ b/lib/domain/core/failure.dart
@@ -1,0 +1,54 @@
+// lib/domain/core/failure.dart
+//
+// Sealed failure hierarchy used as the error payload in Result<T>.
+//
+// Every cross-layer error must be mapped to one of these subtypes before
+// crossing a layer boundary — raw exceptions must never propagate up.
+//
+// Subtypes:
+//   DatabaseFailure       — SQLite / Drift write/read errors
+//   ValidationFailure     — User input or business-rule pre-condition failures
+//   NetworkFailure        — HTTP / connectivity errors (exchange rates, etc.)
+//   NotFoundFailure       — Requested entity does not exist
+//   BusinessRuleFailure   — Domain invariant violations (e.g. posting to deleted account)
+
+/// Base type for all domain-layer error representations.
+///
+/// Carries a human-readable [message] suitable for display or logging.
+sealed class Failure {
+  const Failure(this.message);
+
+  /// Human-readable description of the failure.
+  final String message;
+}
+
+/// Wraps a SQLite / Drift exception that occurred during a database operation.
+final class DatabaseFailure extends Failure {
+  const DatabaseFailure(super.message);
+}
+
+/// Represents an input or pre-condition validation error.
+///
+/// Returned before any database write is attempted when field-level or
+/// cross-field rules are violated.
+final class ValidationFailure extends Failure {
+  const ValidationFailure(super.message);
+}
+
+/// Wraps a network or HTTP error (e.g. exchange-rate fetch failure).
+final class NetworkFailure extends Failure {
+  const NetworkFailure(super.message);
+}
+
+/// Returned when a required entity is absent from the data store.
+final class NotFoundFailure extends Failure {
+  const NotFoundFailure(super.message);
+}
+
+/// Returned when a domain business-rule invariant is violated at use-case level.
+///
+/// Examples: posting to a soft-deleted account, debits ≠ credits on a ledger
+/// transaction, attempting to archive an already-archived template.
+final class BusinessRuleFailure extends Failure {
+  const BusinessRuleFailure(super.message);
+}

--- a/lib/domain/core/result.dart
+++ b/lib/domain/core/result.dart
@@ -1,0 +1,44 @@
+// lib/domain/core/result.dart
+//
+// Result<T> sealed type — explicit success/error return for all repository
+// and use-case boundaries.
+//
+// Usage:
+//   Future<Result<Account>> createAccount(Account account) async { ... }
+//
+//   final result = await createAccount(account);
+//   switch (result) {
+//     case Ok(:final value):  // use value
+//     case Err(:final failure): // handle failure
+//   }
+//
+// Rules (SDS §2.9.3):
+//   - Use cases return Future<Result<T>>; they must never throw.
+//   - Stream-returning methods do NOT use Result<T> — errors surface via
+//     StreamController.addError and are handled at the presentation layer.
+//   - The bang operator (.value!) is prohibited; always switch-exhaust both
+//     branches.
+
+import 'package:variance/domain/core/failure.dart';
+
+/// Sealed return type that makes success and failure explicit in the type
+/// signature, preventing silent error swallowing across layer boundaries.
+sealed class Result<T> {
+  const Result();
+}
+
+/// Successful outcome carrying a [value] of type [T].
+final class Ok<T> extends Result<T> {
+  const Ok(this.value);
+
+  /// The successful result value.
+  final T value;
+}
+
+/// Failed outcome carrying a typed [failure] that describes the error.
+final class Err<T> extends Result<T> {
+  const Err(this.failure);
+
+  /// Structured failure describing why the operation did not succeed.
+  final Failure failure;
+}

--- a/lib/domain/entities/account.dart
+++ b/lib/domain/entities/account.dart
@@ -1,0 +1,82 @@
+// lib/domain/entities/account.dart
+//
+// Account domain entity.
+//
+// Represents a user-facing financial account (bank, credit card, cash, etc.)
+// or a system equity account (EQ). Balances are never stored; they are
+// computed from entries at query time.
+//
+// Key rules:
+//   - currency_code is immutable after creation (TC-044).
+//   - EQ accounts have is_system = true and are hidden from all user views.
+//   - Soft-delete: is_deleted = true; deleted_at is set.
+
+import 'package:freezed_annotation/freezed_annotation.dart';
+
+part 'account.freezed.dart';
+
+/// Category of a financial account.
+enum AccountCategory {
+  cash,
+  bankAccount,
+  creditCard,
+  debitCard,
+  topUpWallet,
+  loan,
+  investment,
+  other,
+  equity,
+}
+
+/// Immutable domain entity for a financial account.
+@freezed
+abstract class Account with _$Account {
+  const factory Account({
+    /// UUID v4 stable identifier.
+    required String id,
+
+    /// User-visible display name.
+    required String name,
+
+    /// Account type discriminator.
+    required AccountCategory accountCategory,
+
+    /// Opening balance in minor units of [currencyCode].
+    ///
+    /// Applied once at account creation; never changed.
+    @Default(0) int initialBalanceMinor,
+
+    /// ISO 4217 code; immutable after creation.
+    required String currencyCode,
+
+    /// Whether to include this account in net worth calculations.
+    @Default(true) bool includeInNetWorth,
+
+    /// Optional free-form note.
+    String? notes,
+
+    /// Soft-delete flag.
+    @Default(false) bool isDeleted,
+
+    /// Unix epoch seconds; set when [isDeleted] becomes true.
+    int? deletedAt,
+
+    /// True for EQ and BAI/BAE accounts; blocks user deletion.
+    @Default(false) bool isProtected,
+
+    /// True for system-generated accounts (EQ per currency); hidden from views.
+    @Default(false) bool isSystem,
+
+    /// User-defined sort position; null = alphabetical.
+    int? displayOrder,
+
+    /// Creation epoch (Unix seconds).
+    required int createdAt,
+
+    /// Last-modified epoch (Unix seconds).
+    required int updatedAt,
+
+    /// JSON escape hatch for forward-compatible extensions.
+    String? metadata,
+  }) = _Account;
+}

--- a/lib/domain/entities/account.freezed.dart
+++ b/lib/domain/entities/account.freezed.dart
@@ -1,0 +1,767 @@
+// GENERATED CODE - DO NOT MODIFY BY HAND
+// coverage:ignore-file
+// ignore_for_file: type=lint
+// ignore_for_file: unused_element, deprecated_member_use, deprecated_member_use_from_same_package, use_function_type_syntax_for_parameters, unnecessary_const, avoid_init_to_null, invalid_override_different_default_values_named, prefer_expression_function_bodies, annotate_overrides, invalid_annotation_target, unnecessary_question_mark
+
+part of 'account.dart';
+
+// **************************************************************************
+// FreezedGenerator
+// **************************************************************************
+
+// dart format off
+T _$identity<T>(T value) => value;
+
+/// @nodoc
+mixin _$Account {
+  /// UUID v4 stable identifier.
+  String get id;
+
+  /// User-visible display name.
+  String get name;
+
+  /// Account type discriminator.
+  AccountCategory get accountCategory;
+
+  /// Opening balance in minor units of [currencyCode].
+  ///
+  /// Applied once at account creation; never changed.
+  int get initialBalanceMinor;
+
+  /// ISO 4217 code; immutable after creation.
+  String get currencyCode;
+
+  /// Whether to include this account in net worth calculations.
+  bool get includeInNetWorth;
+
+  /// Optional free-form note.
+  String? get notes;
+
+  /// Soft-delete flag.
+  bool get isDeleted;
+
+  /// Unix epoch seconds; set when [isDeleted] becomes true.
+  int? get deletedAt;
+
+  /// True for EQ and BAI/BAE accounts; blocks user deletion.
+  bool get isProtected;
+
+  /// True for system-generated accounts (EQ per currency); hidden from views.
+  bool get isSystem;
+
+  /// User-defined sort position; null = alphabetical.
+  int? get displayOrder;
+
+  /// Creation epoch (Unix seconds).
+  int get createdAt;
+
+  /// Last-modified epoch (Unix seconds).
+  int get updatedAt;
+
+  /// JSON escape hatch for forward-compatible extensions.
+  String? get metadata;
+
+  /// Create a copy of Account
+  /// with the given fields replaced by the non-null parameter values.
+  @JsonKey(includeFromJson: false, includeToJson: false)
+  @pragma('vm:prefer-inline')
+  $AccountCopyWith<Account> get copyWith =>
+      _$AccountCopyWithImpl<Account>(this as Account, _$identity);
+
+  @override
+  bool operator ==(Object other) {
+    return identical(this, other) ||
+        (other.runtimeType == runtimeType &&
+            other is Account &&
+            (identical(other.id, id) || other.id == id) &&
+            (identical(other.name, name) || other.name == name) &&
+            (identical(other.accountCategory, accountCategory) ||
+                other.accountCategory == accountCategory) &&
+            (identical(other.initialBalanceMinor, initialBalanceMinor) ||
+                other.initialBalanceMinor == initialBalanceMinor) &&
+            (identical(other.currencyCode, currencyCode) ||
+                other.currencyCode == currencyCode) &&
+            (identical(other.includeInNetWorth, includeInNetWorth) ||
+                other.includeInNetWorth == includeInNetWorth) &&
+            (identical(other.notes, notes) || other.notes == notes) &&
+            (identical(other.isDeleted, isDeleted) ||
+                other.isDeleted == isDeleted) &&
+            (identical(other.deletedAt, deletedAt) ||
+                other.deletedAt == deletedAt) &&
+            (identical(other.isProtected, isProtected) ||
+                other.isProtected == isProtected) &&
+            (identical(other.isSystem, isSystem) ||
+                other.isSystem == isSystem) &&
+            (identical(other.displayOrder, displayOrder) ||
+                other.displayOrder == displayOrder) &&
+            (identical(other.createdAt, createdAt) ||
+                other.createdAt == createdAt) &&
+            (identical(other.updatedAt, updatedAt) ||
+                other.updatedAt == updatedAt) &&
+            (identical(other.metadata, metadata) ||
+                other.metadata == metadata));
+  }
+
+  @override
+  int get hashCode => Object.hash(
+      runtimeType,
+      id,
+      name,
+      accountCategory,
+      initialBalanceMinor,
+      currencyCode,
+      includeInNetWorth,
+      notes,
+      isDeleted,
+      deletedAt,
+      isProtected,
+      isSystem,
+      displayOrder,
+      createdAt,
+      updatedAt,
+      metadata);
+
+  @override
+  String toString() {
+    return 'Account(id: $id, name: $name, accountCategory: $accountCategory, initialBalanceMinor: $initialBalanceMinor, currencyCode: $currencyCode, includeInNetWorth: $includeInNetWorth, notes: $notes, isDeleted: $isDeleted, deletedAt: $deletedAt, isProtected: $isProtected, isSystem: $isSystem, displayOrder: $displayOrder, createdAt: $createdAt, updatedAt: $updatedAt, metadata: $metadata)';
+  }
+}
+
+/// @nodoc
+abstract mixin class $AccountCopyWith<$Res> {
+  factory $AccountCopyWith(Account value, $Res Function(Account) _then) =
+      _$AccountCopyWithImpl;
+  @useResult
+  $Res call(
+      {String id,
+      String name,
+      AccountCategory accountCategory,
+      int initialBalanceMinor,
+      String currencyCode,
+      bool includeInNetWorth,
+      String? notes,
+      bool isDeleted,
+      int? deletedAt,
+      bool isProtected,
+      bool isSystem,
+      int? displayOrder,
+      int createdAt,
+      int updatedAt,
+      String? metadata});
+}
+
+/// @nodoc
+class _$AccountCopyWithImpl<$Res> implements $AccountCopyWith<$Res> {
+  _$AccountCopyWithImpl(this._self, this._then);
+
+  final Account _self;
+  final $Res Function(Account) _then;
+
+  /// Create a copy of Account
+  /// with the given fields replaced by the non-null parameter values.
+  @pragma('vm:prefer-inline')
+  @override
+  $Res call({
+    Object? id = null,
+    Object? name = null,
+    Object? accountCategory = null,
+    Object? initialBalanceMinor = null,
+    Object? currencyCode = null,
+    Object? includeInNetWorth = null,
+    Object? notes = freezed,
+    Object? isDeleted = null,
+    Object? deletedAt = freezed,
+    Object? isProtected = null,
+    Object? isSystem = null,
+    Object? displayOrder = freezed,
+    Object? createdAt = null,
+    Object? updatedAt = null,
+    Object? metadata = freezed,
+  }) {
+    return _then(_self.copyWith(
+      id: null == id
+          ? _self.id
+          : id // ignore: cast_nullable_to_non_nullable
+              as String,
+      name: null == name
+          ? _self.name
+          : name // ignore: cast_nullable_to_non_nullable
+              as String,
+      accountCategory: null == accountCategory
+          ? _self.accountCategory
+          : accountCategory // ignore: cast_nullable_to_non_nullable
+              as AccountCategory,
+      initialBalanceMinor: null == initialBalanceMinor
+          ? _self.initialBalanceMinor
+          : initialBalanceMinor // ignore: cast_nullable_to_non_nullable
+              as int,
+      currencyCode: null == currencyCode
+          ? _self.currencyCode
+          : currencyCode // ignore: cast_nullable_to_non_nullable
+              as String,
+      includeInNetWorth: null == includeInNetWorth
+          ? _self.includeInNetWorth
+          : includeInNetWorth // ignore: cast_nullable_to_non_nullable
+              as bool,
+      notes: freezed == notes
+          ? _self.notes
+          : notes // ignore: cast_nullable_to_non_nullable
+              as String?,
+      isDeleted: null == isDeleted
+          ? _self.isDeleted
+          : isDeleted // ignore: cast_nullable_to_non_nullable
+              as bool,
+      deletedAt: freezed == deletedAt
+          ? _self.deletedAt
+          : deletedAt // ignore: cast_nullable_to_non_nullable
+              as int?,
+      isProtected: null == isProtected
+          ? _self.isProtected
+          : isProtected // ignore: cast_nullable_to_non_nullable
+              as bool,
+      isSystem: null == isSystem
+          ? _self.isSystem
+          : isSystem // ignore: cast_nullable_to_non_nullable
+              as bool,
+      displayOrder: freezed == displayOrder
+          ? _self.displayOrder
+          : displayOrder // ignore: cast_nullable_to_non_nullable
+              as int?,
+      createdAt: null == createdAt
+          ? _self.createdAt
+          : createdAt // ignore: cast_nullable_to_non_nullable
+              as int,
+      updatedAt: null == updatedAt
+          ? _self.updatedAt
+          : updatedAt // ignore: cast_nullable_to_non_nullable
+              as int,
+      metadata: freezed == metadata
+          ? _self.metadata
+          : metadata // ignore: cast_nullable_to_non_nullable
+              as String?,
+    ));
+  }
+}
+
+/// Adds pattern-matching-related methods to [Account].
+extension AccountPatterns on Account {
+  /// A variant of `map` that fallback to returning `orElse`.
+  ///
+  /// It is equivalent to doing:
+  /// ```dart
+  /// switch (sealedClass) {
+  ///   case final Subclass value:
+  ///     return ...;
+  ///   case _:
+  ///     return orElse();
+  /// }
+  /// ```
+
+  @optionalTypeArgs
+  TResult maybeMap<TResult extends Object?>(
+    TResult Function(_Account value)? $default, {
+    required TResult orElse(),
+  }) {
+    final _that = this;
+    switch (_that) {
+      case _Account() when $default != null:
+        return $default(_that);
+      case _:
+        return orElse();
+    }
+  }
+
+  /// A `switch`-like method, using callbacks.
+  ///
+  /// Callbacks receives the raw object, upcasted.
+  /// It is equivalent to doing:
+  /// ```dart
+  /// switch (sealedClass) {
+  ///   case final Subclass value:
+  ///     return ...;
+  ///   case final Subclass2 value:
+  ///     return ...;
+  /// }
+  /// ```
+
+  @optionalTypeArgs
+  TResult map<TResult extends Object?>(
+    TResult Function(_Account value) $default,
+  ) {
+    final _that = this;
+    switch (_that) {
+      case _Account():
+        return $default(_that);
+      case _:
+        throw StateError('Unexpected subclass');
+    }
+  }
+
+  /// A variant of `map` that fallback to returning `null`.
+  ///
+  /// It is equivalent to doing:
+  /// ```dart
+  /// switch (sealedClass) {
+  ///   case final Subclass value:
+  ///     return ...;
+  ///   case _:
+  ///     return null;
+  /// }
+  /// ```
+
+  @optionalTypeArgs
+  TResult? mapOrNull<TResult extends Object?>(
+    TResult? Function(_Account value)? $default,
+  ) {
+    final _that = this;
+    switch (_that) {
+      case _Account() when $default != null:
+        return $default(_that);
+      case _:
+        return null;
+    }
+  }
+
+  /// A variant of `when` that fallback to an `orElse` callback.
+  ///
+  /// It is equivalent to doing:
+  /// ```dart
+  /// switch (sealedClass) {
+  ///   case Subclass(:final field):
+  ///     return ...;
+  ///   case _:
+  ///     return orElse();
+  /// }
+  /// ```
+
+  @optionalTypeArgs
+  TResult maybeWhen<TResult extends Object?>(
+    TResult Function(
+            String id,
+            String name,
+            AccountCategory accountCategory,
+            int initialBalanceMinor,
+            String currencyCode,
+            bool includeInNetWorth,
+            String? notes,
+            bool isDeleted,
+            int? deletedAt,
+            bool isProtected,
+            bool isSystem,
+            int? displayOrder,
+            int createdAt,
+            int updatedAt,
+            String? metadata)?
+        $default, {
+    required TResult orElse(),
+  }) {
+    final _that = this;
+    switch (_that) {
+      case _Account() when $default != null:
+        return $default(
+            _that.id,
+            _that.name,
+            _that.accountCategory,
+            _that.initialBalanceMinor,
+            _that.currencyCode,
+            _that.includeInNetWorth,
+            _that.notes,
+            _that.isDeleted,
+            _that.deletedAt,
+            _that.isProtected,
+            _that.isSystem,
+            _that.displayOrder,
+            _that.createdAt,
+            _that.updatedAt,
+            _that.metadata);
+      case _:
+        return orElse();
+    }
+  }
+
+  /// A `switch`-like method, using callbacks.
+  ///
+  /// As opposed to `map`, this offers destructuring.
+  /// It is equivalent to doing:
+  /// ```dart
+  /// switch (sealedClass) {
+  ///   case Subclass(:final field):
+  ///     return ...;
+  ///   case Subclass2(:final field2):
+  ///     return ...;
+  /// }
+  /// ```
+
+  @optionalTypeArgs
+  TResult when<TResult extends Object?>(
+    TResult Function(
+            String id,
+            String name,
+            AccountCategory accountCategory,
+            int initialBalanceMinor,
+            String currencyCode,
+            bool includeInNetWorth,
+            String? notes,
+            bool isDeleted,
+            int? deletedAt,
+            bool isProtected,
+            bool isSystem,
+            int? displayOrder,
+            int createdAt,
+            int updatedAt,
+            String? metadata)
+        $default,
+  ) {
+    final _that = this;
+    switch (_that) {
+      case _Account():
+        return $default(
+            _that.id,
+            _that.name,
+            _that.accountCategory,
+            _that.initialBalanceMinor,
+            _that.currencyCode,
+            _that.includeInNetWorth,
+            _that.notes,
+            _that.isDeleted,
+            _that.deletedAt,
+            _that.isProtected,
+            _that.isSystem,
+            _that.displayOrder,
+            _that.createdAt,
+            _that.updatedAt,
+            _that.metadata);
+      case _:
+        throw StateError('Unexpected subclass');
+    }
+  }
+
+  /// A variant of `when` that fallback to returning `null`
+  ///
+  /// It is equivalent to doing:
+  /// ```dart
+  /// switch (sealedClass) {
+  ///   case Subclass(:final field):
+  ///     return ...;
+  ///   case _:
+  ///     return null;
+  /// }
+  /// ```
+
+  @optionalTypeArgs
+  TResult? whenOrNull<TResult extends Object?>(
+    TResult? Function(
+            String id,
+            String name,
+            AccountCategory accountCategory,
+            int initialBalanceMinor,
+            String currencyCode,
+            bool includeInNetWorth,
+            String? notes,
+            bool isDeleted,
+            int? deletedAt,
+            bool isProtected,
+            bool isSystem,
+            int? displayOrder,
+            int createdAt,
+            int updatedAt,
+            String? metadata)?
+        $default,
+  ) {
+    final _that = this;
+    switch (_that) {
+      case _Account() when $default != null:
+        return $default(
+            _that.id,
+            _that.name,
+            _that.accountCategory,
+            _that.initialBalanceMinor,
+            _that.currencyCode,
+            _that.includeInNetWorth,
+            _that.notes,
+            _that.isDeleted,
+            _that.deletedAt,
+            _that.isProtected,
+            _that.isSystem,
+            _that.displayOrder,
+            _that.createdAt,
+            _that.updatedAt,
+            _that.metadata);
+      case _:
+        return null;
+    }
+  }
+}
+
+/// @nodoc
+
+class _Account implements Account {
+  const _Account(
+      {required this.id,
+      required this.name,
+      required this.accountCategory,
+      this.initialBalanceMinor = 0,
+      required this.currencyCode,
+      this.includeInNetWorth = true,
+      this.notes,
+      this.isDeleted = false,
+      this.deletedAt,
+      this.isProtected = false,
+      this.isSystem = false,
+      this.displayOrder,
+      required this.createdAt,
+      required this.updatedAt,
+      this.metadata});
+
+  /// UUID v4 stable identifier.
+  @override
+  final String id;
+
+  /// User-visible display name.
+  @override
+  final String name;
+
+  /// Account type discriminator.
+  @override
+  final AccountCategory accountCategory;
+
+  /// Opening balance in minor units of [currencyCode].
+  ///
+  /// Applied once at account creation; never changed.
+  @override
+  @JsonKey()
+  final int initialBalanceMinor;
+
+  /// ISO 4217 code; immutable after creation.
+  @override
+  final String currencyCode;
+
+  /// Whether to include this account in net worth calculations.
+  @override
+  @JsonKey()
+  final bool includeInNetWorth;
+
+  /// Optional free-form note.
+  @override
+  final String? notes;
+
+  /// Soft-delete flag.
+  @override
+  @JsonKey()
+  final bool isDeleted;
+
+  /// Unix epoch seconds; set when [isDeleted] becomes true.
+  @override
+  final int? deletedAt;
+
+  /// True for EQ and BAI/BAE accounts; blocks user deletion.
+  @override
+  @JsonKey()
+  final bool isProtected;
+
+  /// True for system-generated accounts (EQ per currency); hidden from views.
+  @override
+  @JsonKey()
+  final bool isSystem;
+
+  /// User-defined sort position; null = alphabetical.
+  @override
+  final int? displayOrder;
+
+  /// Creation epoch (Unix seconds).
+  @override
+  final int createdAt;
+
+  /// Last-modified epoch (Unix seconds).
+  @override
+  final int updatedAt;
+
+  /// JSON escape hatch for forward-compatible extensions.
+  @override
+  final String? metadata;
+
+  /// Create a copy of Account
+  /// with the given fields replaced by the non-null parameter values.
+  @override
+  @JsonKey(includeFromJson: false, includeToJson: false)
+  @pragma('vm:prefer-inline')
+  _$AccountCopyWith<_Account> get copyWith =>
+      __$AccountCopyWithImpl<_Account>(this, _$identity);
+
+  @override
+  bool operator ==(Object other) {
+    return identical(this, other) ||
+        (other.runtimeType == runtimeType &&
+            other is _Account &&
+            (identical(other.id, id) || other.id == id) &&
+            (identical(other.name, name) || other.name == name) &&
+            (identical(other.accountCategory, accountCategory) ||
+                other.accountCategory == accountCategory) &&
+            (identical(other.initialBalanceMinor, initialBalanceMinor) ||
+                other.initialBalanceMinor == initialBalanceMinor) &&
+            (identical(other.currencyCode, currencyCode) ||
+                other.currencyCode == currencyCode) &&
+            (identical(other.includeInNetWorth, includeInNetWorth) ||
+                other.includeInNetWorth == includeInNetWorth) &&
+            (identical(other.notes, notes) || other.notes == notes) &&
+            (identical(other.isDeleted, isDeleted) ||
+                other.isDeleted == isDeleted) &&
+            (identical(other.deletedAt, deletedAt) ||
+                other.deletedAt == deletedAt) &&
+            (identical(other.isProtected, isProtected) ||
+                other.isProtected == isProtected) &&
+            (identical(other.isSystem, isSystem) ||
+                other.isSystem == isSystem) &&
+            (identical(other.displayOrder, displayOrder) ||
+                other.displayOrder == displayOrder) &&
+            (identical(other.createdAt, createdAt) ||
+                other.createdAt == createdAt) &&
+            (identical(other.updatedAt, updatedAt) ||
+                other.updatedAt == updatedAt) &&
+            (identical(other.metadata, metadata) ||
+                other.metadata == metadata));
+  }
+
+  @override
+  int get hashCode => Object.hash(
+      runtimeType,
+      id,
+      name,
+      accountCategory,
+      initialBalanceMinor,
+      currencyCode,
+      includeInNetWorth,
+      notes,
+      isDeleted,
+      deletedAt,
+      isProtected,
+      isSystem,
+      displayOrder,
+      createdAt,
+      updatedAt,
+      metadata);
+
+  @override
+  String toString() {
+    return 'Account(id: $id, name: $name, accountCategory: $accountCategory, initialBalanceMinor: $initialBalanceMinor, currencyCode: $currencyCode, includeInNetWorth: $includeInNetWorth, notes: $notes, isDeleted: $isDeleted, deletedAt: $deletedAt, isProtected: $isProtected, isSystem: $isSystem, displayOrder: $displayOrder, createdAt: $createdAt, updatedAt: $updatedAt, metadata: $metadata)';
+  }
+}
+
+/// @nodoc
+abstract mixin class _$AccountCopyWith<$Res> implements $AccountCopyWith<$Res> {
+  factory _$AccountCopyWith(_Account value, $Res Function(_Account) _then) =
+      __$AccountCopyWithImpl;
+  @override
+  @useResult
+  $Res call(
+      {String id,
+      String name,
+      AccountCategory accountCategory,
+      int initialBalanceMinor,
+      String currencyCode,
+      bool includeInNetWorth,
+      String? notes,
+      bool isDeleted,
+      int? deletedAt,
+      bool isProtected,
+      bool isSystem,
+      int? displayOrder,
+      int createdAt,
+      int updatedAt,
+      String? metadata});
+}
+
+/// @nodoc
+class __$AccountCopyWithImpl<$Res> implements _$AccountCopyWith<$Res> {
+  __$AccountCopyWithImpl(this._self, this._then);
+
+  final _Account _self;
+  final $Res Function(_Account) _then;
+
+  /// Create a copy of Account
+  /// with the given fields replaced by the non-null parameter values.
+  @override
+  @pragma('vm:prefer-inline')
+  $Res call({
+    Object? id = null,
+    Object? name = null,
+    Object? accountCategory = null,
+    Object? initialBalanceMinor = null,
+    Object? currencyCode = null,
+    Object? includeInNetWorth = null,
+    Object? notes = freezed,
+    Object? isDeleted = null,
+    Object? deletedAt = freezed,
+    Object? isProtected = null,
+    Object? isSystem = null,
+    Object? displayOrder = freezed,
+    Object? createdAt = null,
+    Object? updatedAt = null,
+    Object? metadata = freezed,
+  }) {
+    return _then(_Account(
+      id: null == id
+          ? _self.id
+          : id // ignore: cast_nullable_to_non_nullable
+              as String,
+      name: null == name
+          ? _self.name
+          : name // ignore: cast_nullable_to_non_nullable
+              as String,
+      accountCategory: null == accountCategory
+          ? _self.accountCategory
+          : accountCategory // ignore: cast_nullable_to_non_nullable
+              as AccountCategory,
+      initialBalanceMinor: null == initialBalanceMinor
+          ? _self.initialBalanceMinor
+          : initialBalanceMinor // ignore: cast_nullable_to_non_nullable
+              as int,
+      currencyCode: null == currencyCode
+          ? _self.currencyCode
+          : currencyCode // ignore: cast_nullable_to_non_nullable
+              as String,
+      includeInNetWorth: null == includeInNetWorth
+          ? _self.includeInNetWorth
+          : includeInNetWorth // ignore: cast_nullable_to_non_nullable
+              as bool,
+      notes: freezed == notes
+          ? _self.notes
+          : notes // ignore: cast_nullable_to_non_nullable
+              as String?,
+      isDeleted: null == isDeleted
+          ? _self.isDeleted
+          : isDeleted // ignore: cast_nullable_to_non_nullable
+              as bool,
+      deletedAt: freezed == deletedAt
+          ? _self.deletedAt
+          : deletedAt // ignore: cast_nullable_to_non_nullable
+              as int?,
+      isProtected: null == isProtected
+          ? _self.isProtected
+          : isProtected // ignore: cast_nullable_to_non_nullable
+              as bool,
+      isSystem: null == isSystem
+          ? _self.isSystem
+          : isSystem // ignore: cast_nullable_to_non_nullable
+              as bool,
+      displayOrder: freezed == displayOrder
+          ? _self.displayOrder
+          : displayOrder // ignore: cast_nullable_to_non_nullable
+              as int?,
+      createdAt: null == createdAt
+          ? _self.createdAt
+          : createdAt // ignore: cast_nullable_to_non_nullable
+              as int,
+      updatedAt: null == updatedAt
+          ? _self.updatedAt
+          : updatedAt // ignore: cast_nullable_to_non_nullable
+              as int,
+      metadata: freezed == metadata
+          ? _self.metadata
+          : metadata // ignore: cast_nullable_to_non_nullable
+              as String?,
+    ));
+  }
+}
+
+// dart format on

--- a/lib/domain/entities/app_settings.dart
+++ b/lib/domain/entities/app_settings.dart
@@ -1,0 +1,132 @@
+// lib/domain/entities/app_settings.dart
+//
+// AppSettings domain entity.
+//
+// Flat value object mirroring all v1 app_settings key-value rows as typed
+// Dart fields. The data layer reads the KV rows and maps them into this
+// entity; the domain and presentation layers work with this typed object.
+//
+// Defined keys match data model §9.1.
+
+import 'package:freezed_annotation/freezed_annotation.dart';
+
+part 'app_settings.freezed.dart';
+
+/// Visual theme mode.
+enum AppTheme {
+  light,
+  dark,
+  system,
+}
+
+/// Color scheme source.
+enum ColorSchemeMode {
+  dynamic,
+  custom,
+}
+
+/// Decimal separator for number display.
+enum DecimalSeparator {
+  comma,
+  period,
+}
+
+/// Thousands grouping style.
+enum ThousandsGrouping {
+  standard,
+  indian,
+}
+
+/// Currency symbol placement.
+enum CurrencySymbolPlacement {
+  prefix,
+  suffix,
+}
+
+/// Spacing between currency symbol and amount.
+enum CurrencySymbolSpacing {
+  none,
+  space,
+}
+
+/// Start of week.
+enum WeekStart {
+  monday,
+  sunday,
+}
+
+/// Clock format preference.
+enum TimeFormat {
+  h12,
+  h24,
+}
+
+/// Back-button behaviour on transaction entry form.
+enum BackButtonBehaviour {
+  ask,
+  autoSaveDraft,
+  discard,
+}
+
+/// Immutable flat domain entity for all v1 user preferences.
+@freezed
+abstract class AppSettings with _$AppSettings {
+  const factory AppSettings({
+    /// ISO 4217 home currency code; set during onboarding.
+    @Default('INR') String homeCurrency,
+
+    /// Light/dark/system theme.
+    @Default(AppTheme.system) AppTheme theme,
+
+    /// Dynamic (wallpaper) or custom seed color scheme.
+    @Default(ColorSchemeMode.dynamic) ColorSchemeMode colorSchemeMode,
+
+    /// Hex seed color for custom color scheme; null when dynamic.
+    String? colorSeed,
+
+    /// Whether in-app animations are enabled.
+    @Default(true) bool animationsEnabled,
+
+    /// Decimal separator preference.
+    DecimalSeparator? numberDecimalSeparator,
+
+    /// Thousands grouping style.
+    ThousandsGrouping? numberThousandsGrouping,
+
+    /// Currency symbol placement.
+    CurrencySymbolPlacement? currencySymbolPlacement,
+
+    /// Spacing between currency symbol and amount.
+    CurrencySymbolSpacing? currencySymbolSpacing,
+
+    /// Week start day.
+    @Default(WeekStart.monday) WeekStart weekStart,
+
+    /// 12h or 24h time display.
+    TimeFormat? timeFormat,
+
+    /// Percentage display precision (0, 1, or 2).
+    @Default(0) int percentagePrecision,
+
+    /// Maximum character count for transaction descriptions.
+    @Default(1000) int descriptionMaxLength,
+
+    /// Back button behaviour on unsaved form.
+    @Default(BackButtonBehaviour.ask) BackButtonBehaviour backButtonBehaviour,
+
+    /// Idle timeout before app-lock; 0 = lock immediately.
+    @Default(0) int lockTimeoutSeconds,
+
+    /// Optional greeting name shown on the home screen.
+    String? displayName,
+
+    /// Whether onboarding has been completed.
+    @Default(false) bool onboardingComplete,
+
+    /// Backup format version (TC-054).
+    @Default(1) int schemaBackupVersion,
+
+    /// Unix epoch of the last successful exchange rate fetch.
+    int? lastExchangeRateFetch,
+  }) = _AppSettings;
+}

--- a/lib/domain/entities/app_settings.freezed.dart
+++ b/lib/domain/entities/app_settings.freezed.dart
@@ -1,0 +1,910 @@
+// GENERATED CODE - DO NOT MODIFY BY HAND
+// coverage:ignore-file
+// ignore_for_file: type=lint
+// ignore_for_file: unused_element, deprecated_member_use, deprecated_member_use_from_same_package, use_function_type_syntax_for_parameters, unnecessary_const, avoid_init_to_null, invalid_override_different_default_values_named, prefer_expression_function_bodies, annotate_overrides, invalid_annotation_target, unnecessary_question_mark
+
+part of 'app_settings.dart';
+
+// **************************************************************************
+// FreezedGenerator
+// **************************************************************************
+
+// dart format off
+T _$identity<T>(T value) => value;
+
+/// @nodoc
+mixin _$AppSettings {
+  /// ISO 4217 home currency code; set during onboarding.
+  String get homeCurrency;
+
+  /// Light/dark/system theme.
+  AppTheme get theme;
+
+  /// Dynamic (wallpaper) or custom seed color scheme.
+  ColorSchemeMode get colorSchemeMode;
+
+  /// Hex seed color for custom color scheme; null when dynamic.
+  String? get colorSeed;
+
+  /// Whether in-app animations are enabled.
+  bool get animationsEnabled;
+
+  /// Decimal separator preference.
+  DecimalSeparator? get numberDecimalSeparator;
+
+  /// Thousands grouping style.
+  ThousandsGrouping? get numberThousandsGrouping;
+
+  /// Currency symbol placement.
+  CurrencySymbolPlacement? get currencySymbolPlacement;
+
+  /// Spacing between currency symbol and amount.
+  CurrencySymbolSpacing? get currencySymbolSpacing;
+
+  /// Week start day.
+  WeekStart get weekStart;
+
+  /// 12h or 24h time display.
+  TimeFormat? get timeFormat;
+
+  /// Percentage display precision (0, 1, or 2).
+  int get percentagePrecision;
+
+  /// Maximum character count for transaction descriptions.
+  int get descriptionMaxLength;
+
+  /// Back button behaviour on unsaved form.
+  BackButtonBehaviour get backButtonBehaviour;
+
+  /// Idle timeout before app-lock; 0 = lock immediately.
+  int get lockTimeoutSeconds;
+
+  /// Optional greeting name shown on the home screen.
+  String? get displayName;
+
+  /// Whether onboarding has been completed.
+  bool get onboardingComplete;
+
+  /// Backup format version (TC-054).
+  int get schemaBackupVersion;
+
+  /// Unix epoch of the last successful exchange rate fetch.
+  int? get lastExchangeRateFetch;
+
+  /// Create a copy of AppSettings
+  /// with the given fields replaced by the non-null parameter values.
+  @JsonKey(includeFromJson: false, includeToJson: false)
+  @pragma('vm:prefer-inline')
+  $AppSettingsCopyWith<AppSettings> get copyWith =>
+      _$AppSettingsCopyWithImpl<AppSettings>(this as AppSettings, _$identity);
+
+  @override
+  bool operator ==(Object other) {
+    return identical(this, other) ||
+        (other.runtimeType == runtimeType &&
+            other is AppSettings &&
+            (identical(other.homeCurrency, homeCurrency) ||
+                other.homeCurrency == homeCurrency) &&
+            (identical(other.theme, theme) || other.theme == theme) &&
+            (identical(other.colorSchemeMode, colorSchemeMode) ||
+                other.colorSchemeMode == colorSchemeMode) &&
+            (identical(other.colorSeed, colorSeed) ||
+                other.colorSeed == colorSeed) &&
+            (identical(other.animationsEnabled, animationsEnabled) ||
+                other.animationsEnabled == animationsEnabled) &&
+            (identical(other.numberDecimalSeparator, numberDecimalSeparator) ||
+                other.numberDecimalSeparator == numberDecimalSeparator) &&
+            (identical(
+                    other.numberThousandsGrouping, numberThousandsGrouping) ||
+                other.numberThousandsGrouping == numberThousandsGrouping) &&
+            (identical(
+                    other.currencySymbolPlacement, currencySymbolPlacement) ||
+                other.currencySymbolPlacement == currencySymbolPlacement) &&
+            (identical(other.currencySymbolSpacing, currencySymbolSpacing) ||
+                other.currencySymbolSpacing == currencySymbolSpacing) &&
+            (identical(other.weekStart, weekStart) ||
+                other.weekStart == weekStart) &&
+            (identical(other.timeFormat, timeFormat) ||
+                other.timeFormat == timeFormat) &&
+            (identical(other.percentagePrecision, percentagePrecision) ||
+                other.percentagePrecision == percentagePrecision) &&
+            (identical(other.descriptionMaxLength, descriptionMaxLength) ||
+                other.descriptionMaxLength == descriptionMaxLength) &&
+            (identical(other.backButtonBehaviour, backButtonBehaviour) ||
+                other.backButtonBehaviour == backButtonBehaviour) &&
+            (identical(other.lockTimeoutSeconds, lockTimeoutSeconds) ||
+                other.lockTimeoutSeconds == lockTimeoutSeconds) &&
+            (identical(other.displayName, displayName) ||
+                other.displayName == displayName) &&
+            (identical(other.onboardingComplete, onboardingComplete) ||
+                other.onboardingComplete == onboardingComplete) &&
+            (identical(other.schemaBackupVersion, schemaBackupVersion) ||
+                other.schemaBackupVersion == schemaBackupVersion) &&
+            (identical(other.lastExchangeRateFetch, lastExchangeRateFetch) ||
+                other.lastExchangeRateFetch == lastExchangeRateFetch));
+  }
+
+  @override
+  int get hashCode => Object.hashAll([
+        runtimeType,
+        homeCurrency,
+        theme,
+        colorSchemeMode,
+        colorSeed,
+        animationsEnabled,
+        numberDecimalSeparator,
+        numberThousandsGrouping,
+        currencySymbolPlacement,
+        currencySymbolSpacing,
+        weekStart,
+        timeFormat,
+        percentagePrecision,
+        descriptionMaxLength,
+        backButtonBehaviour,
+        lockTimeoutSeconds,
+        displayName,
+        onboardingComplete,
+        schemaBackupVersion,
+        lastExchangeRateFetch
+      ]);
+
+  @override
+  String toString() {
+    return 'AppSettings(homeCurrency: $homeCurrency, theme: $theme, colorSchemeMode: $colorSchemeMode, colorSeed: $colorSeed, animationsEnabled: $animationsEnabled, numberDecimalSeparator: $numberDecimalSeparator, numberThousandsGrouping: $numberThousandsGrouping, currencySymbolPlacement: $currencySymbolPlacement, currencySymbolSpacing: $currencySymbolSpacing, weekStart: $weekStart, timeFormat: $timeFormat, percentagePrecision: $percentagePrecision, descriptionMaxLength: $descriptionMaxLength, backButtonBehaviour: $backButtonBehaviour, lockTimeoutSeconds: $lockTimeoutSeconds, displayName: $displayName, onboardingComplete: $onboardingComplete, schemaBackupVersion: $schemaBackupVersion, lastExchangeRateFetch: $lastExchangeRateFetch)';
+  }
+}
+
+/// @nodoc
+abstract mixin class $AppSettingsCopyWith<$Res> {
+  factory $AppSettingsCopyWith(
+          AppSettings value, $Res Function(AppSettings) _then) =
+      _$AppSettingsCopyWithImpl;
+  @useResult
+  $Res call(
+      {String homeCurrency,
+      AppTheme theme,
+      ColorSchemeMode colorSchemeMode,
+      String? colorSeed,
+      bool animationsEnabled,
+      DecimalSeparator? numberDecimalSeparator,
+      ThousandsGrouping? numberThousandsGrouping,
+      CurrencySymbolPlacement? currencySymbolPlacement,
+      CurrencySymbolSpacing? currencySymbolSpacing,
+      WeekStart weekStart,
+      TimeFormat? timeFormat,
+      int percentagePrecision,
+      int descriptionMaxLength,
+      BackButtonBehaviour backButtonBehaviour,
+      int lockTimeoutSeconds,
+      String? displayName,
+      bool onboardingComplete,
+      int schemaBackupVersion,
+      int? lastExchangeRateFetch});
+}
+
+/// @nodoc
+class _$AppSettingsCopyWithImpl<$Res> implements $AppSettingsCopyWith<$Res> {
+  _$AppSettingsCopyWithImpl(this._self, this._then);
+
+  final AppSettings _self;
+  final $Res Function(AppSettings) _then;
+
+  /// Create a copy of AppSettings
+  /// with the given fields replaced by the non-null parameter values.
+  @pragma('vm:prefer-inline')
+  @override
+  $Res call({
+    Object? homeCurrency = null,
+    Object? theme = null,
+    Object? colorSchemeMode = null,
+    Object? colorSeed = freezed,
+    Object? animationsEnabled = null,
+    Object? numberDecimalSeparator = freezed,
+    Object? numberThousandsGrouping = freezed,
+    Object? currencySymbolPlacement = freezed,
+    Object? currencySymbolSpacing = freezed,
+    Object? weekStart = null,
+    Object? timeFormat = freezed,
+    Object? percentagePrecision = null,
+    Object? descriptionMaxLength = null,
+    Object? backButtonBehaviour = null,
+    Object? lockTimeoutSeconds = null,
+    Object? displayName = freezed,
+    Object? onboardingComplete = null,
+    Object? schemaBackupVersion = null,
+    Object? lastExchangeRateFetch = freezed,
+  }) {
+    return _then(_self.copyWith(
+      homeCurrency: null == homeCurrency
+          ? _self.homeCurrency
+          : homeCurrency // ignore: cast_nullable_to_non_nullable
+              as String,
+      theme: null == theme
+          ? _self.theme
+          : theme // ignore: cast_nullable_to_non_nullable
+              as AppTheme,
+      colorSchemeMode: null == colorSchemeMode
+          ? _self.colorSchemeMode
+          : colorSchemeMode // ignore: cast_nullable_to_non_nullable
+              as ColorSchemeMode,
+      colorSeed: freezed == colorSeed
+          ? _self.colorSeed
+          : colorSeed // ignore: cast_nullable_to_non_nullable
+              as String?,
+      animationsEnabled: null == animationsEnabled
+          ? _self.animationsEnabled
+          : animationsEnabled // ignore: cast_nullable_to_non_nullable
+              as bool,
+      numberDecimalSeparator: freezed == numberDecimalSeparator
+          ? _self.numberDecimalSeparator
+          : numberDecimalSeparator // ignore: cast_nullable_to_non_nullable
+              as DecimalSeparator?,
+      numberThousandsGrouping: freezed == numberThousandsGrouping
+          ? _self.numberThousandsGrouping
+          : numberThousandsGrouping // ignore: cast_nullable_to_non_nullable
+              as ThousandsGrouping?,
+      currencySymbolPlacement: freezed == currencySymbolPlacement
+          ? _self.currencySymbolPlacement
+          : currencySymbolPlacement // ignore: cast_nullable_to_non_nullable
+              as CurrencySymbolPlacement?,
+      currencySymbolSpacing: freezed == currencySymbolSpacing
+          ? _self.currencySymbolSpacing
+          : currencySymbolSpacing // ignore: cast_nullable_to_non_nullable
+              as CurrencySymbolSpacing?,
+      weekStart: null == weekStart
+          ? _self.weekStart
+          : weekStart // ignore: cast_nullable_to_non_nullable
+              as WeekStart,
+      timeFormat: freezed == timeFormat
+          ? _self.timeFormat
+          : timeFormat // ignore: cast_nullable_to_non_nullable
+              as TimeFormat?,
+      percentagePrecision: null == percentagePrecision
+          ? _self.percentagePrecision
+          : percentagePrecision // ignore: cast_nullable_to_non_nullable
+              as int,
+      descriptionMaxLength: null == descriptionMaxLength
+          ? _self.descriptionMaxLength
+          : descriptionMaxLength // ignore: cast_nullable_to_non_nullable
+              as int,
+      backButtonBehaviour: null == backButtonBehaviour
+          ? _self.backButtonBehaviour
+          : backButtonBehaviour // ignore: cast_nullable_to_non_nullable
+              as BackButtonBehaviour,
+      lockTimeoutSeconds: null == lockTimeoutSeconds
+          ? _self.lockTimeoutSeconds
+          : lockTimeoutSeconds // ignore: cast_nullable_to_non_nullable
+              as int,
+      displayName: freezed == displayName
+          ? _self.displayName
+          : displayName // ignore: cast_nullable_to_non_nullable
+              as String?,
+      onboardingComplete: null == onboardingComplete
+          ? _self.onboardingComplete
+          : onboardingComplete // ignore: cast_nullable_to_non_nullable
+              as bool,
+      schemaBackupVersion: null == schemaBackupVersion
+          ? _self.schemaBackupVersion
+          : schemaBackupVersion // ignore: cast_nullable_to_non_nullable
+              as int,
+      lastExchangeRateFetch: freezed == lastExchangeRateFetch
+          ? _self.lastExchangeRateFetch
+          : lastExchangeRateFetch // ignore: cast_nullable_to_non_nullable
+              as int?,
+    ));
+  }
+}
+
+/// Adds pattern-matching-related methods to [AppSettings].
+extension AppSettingsPatterns on AppSettings {
+  /// A variant of `map` that fallback to returning `orElse`.
+  ///
+  /// It is equivalent to doing:
+  /// ```dart
+  /// switch (sealedClass) {
+  ///   case final Subclass value:
+  ///     return ...;
+  ///   case _:
+  ///     return orElse();
+  /// }
+  /// ```
+
+  @optionalTypeArgs
+  TResult maybeMap<TResult extends Object?>(
+    TResult Function(_AppSettings value)? $default, {
+    required TResult orElse(),
+  }) {
+    final _that = this;
+    switch (_that) {
+      case _AppSettings() when $default != null:
+        return $default(_that);
+      case _:
+        return orElse();
+    }
+  }
+
+  /// A `switch`-like method, using callbacks.
+  ///
+  /// Callbacks receives the raw object, upcasted.
+  /// It is equivalent to doing:
+  /// ```dart
+  /// switch (sealedClass) {
+  ///   case final Subclass value:
+  ///     return ...;
+  ///   case final Subclass2 value:
+  ///     return ...;
+  /// }
+  /// ```
+
+  @optionalTypeArgs
+  TResult map<TResult extends Object?>(
+    TResult Function(_AppSettings value) $default,
+  ) {
+    final _that = this;
+    switch (_that) {
+      case _AppSettings():
+        return $default(_that);
+      case _:
+        throw StateError('Unexpected subclass');
+    }
+  }
+
+  /// A variant of `map` that fallback to returning `null`.
+  ///
+  /// It is equivalent to doing:
+  /// ```dart
+  /// switch (sealedClass) {
+  ///   case final Subclass value:
+  ///     return ...;
+  ///   case _:
+  ///     return null;
+  /// }
+  /// ```
+
+  @optionalTypeArgs
+  TResult? mapOrNull<TResult extends Object?>(
+    TResult? Function(_AppSettings value)? $default,
+  ) {
+    final _that = this;
+    switch (_that) {
+      case _AppSettings() when $default != null:
+        return $default(_that);
+      case _:
+        return null;
+    }
+  }
+
+  /// A variant of `when` that fallback to an `orElse` callback.
+  ///
+  /// It is equivalent to doing:
+  /// ```dart
+  /// switch (sealedClass) {
+  ///   case Subclass(:final field):
+  ///     return ...;
+  ///   case _:
+  ///     return orElse();
+  /// }
+  /// ```
+
+  @optionalTypeArgs
+  TResult maybeWhen<TResult extends Object?>(
+    TResult Function(
+            String homeCurrency,
+            AppTheme theme,
+            ColorSchemeMode colorSchemeMode,
+            String? colorSeed,
+            bool animationsEnabled,
+            DecimalSeparator? numberDecimalSeparator,
+            ThousandsGrouping? numberThousandsGrouping,
+            CurrencySymbolPlacement? currencySymbolPlacement,
+            CurrencySymbolSpacing? currencySymbolSpacing,
+            WeekStart weekStart,
+            TimeFormat? timeFormat,
+            int percentagePrecision,
+            int descriptionMaxLength,
+            BackButtonBehaviour backButtonBehaviour,
+            int lockTimeoutSeconds,
+            String? displayName,
+            bool onboardingComplete,
+            int schemaBackupVersion,
+            int? lastExchangeRateFetch)?
+        $default, {
+    required TResult orElse(),
+  }) {
+    final _that = this;
+    switch (_that) {
+      case _AppSettings() when $default != null:
+        return $default(
+            _that.homeCurrency,
+            _that.theme,
+            _that.colorSchemeMode,
+            _that.colorSeed,
+            _that.animationsEnabled,
+            _that.numberDecimalSeparator,
+            _that.numberThousandsGrouping,
+            _that.currencySymbolPlacement,
+            _that.currencySymbolSpacing,
+            _that.weekStart,
+            _that.timeFormat,
+            _that.percentagePrecision,
+            _that.descriptionMaxLength,
+            _that.backButtonBehaviour,
+            _that.lockTimeoutSeconds,
+            _that.displayName,
+            _that.onboardingComplete,
+            _that.schemaBackupVersion,
+            _that.lastExchangeRateFetch);
+      case _:
+        return orElse();
+    }
+  }
+
+  /// A `switch`-like method, using callbacks.
+  ///
+  /// As opposed to `map`, this offers destructuring.
+  /// It is equivalent to doing:
+  /// ```dart
+  /// switch (sealedClass) {
+  ///   case Subclass(:final field):
+  ///     return ...;
+  ///   case Subclass2(:final field2):
+  ///     return ...;
+  /// }
+  /// ```
+
+  @optionalTypeArgs
+  TResult when<TResult extends Object?>(
+    TResult Function(
+            String homeCurrency,
+            AppTheme theme,
+            ColorSchemeMode colorSchemeMode,
+            String? colorSeed,
+            bool animationsEnabled,
+            DecimalSeparator? numberDecimalSeparator,
+            ThousandsGrouping? numberThousandsGrouping,
+            CurrencySymbolPlacement? currencySymbolPlacement,
+            CurrencySymbolSpacing? currencySymbolSpacing,
+            WeekStart weekStart,
+            TimeFormat? timeFormat,
+            int percentagePrecision,
+            int descriptionMaxLength,
+            BackButtonBehaviour backButtonBehaviour,
+            int lockTimeoutSeconds,
+            String? displayName,
+            bool onboardingComplete,
+            int schemaBackupVersion,
+            int? lastExchangeRateFetch)
+        $default,
+  ) {
+    final _that = this;
+    switch (_that) {
+      case _AppSettings():
+        return $default(
+            _that.homeCurrency,
+            _that.theme,
+            _that.colorSchemeMode,
+            _that.colorSeed,
+            _that.animationsEnabled,
+            _that.numberDecimalSeparator,
+            _that.numberThousandsGrouping,
+            _that.currencySymbolPlacement,
+            _that.currencySymbolSpacing,
+            _that.weekStart,
+            _that.timeFormat,
+            _that.percentagePrecision,
+            _that.descriptionMaxLength,
+            _that.backButtonBehaviour,
+            _that.lockTimeoutSeconds,
+            _that.displayName,
+            _that.onboardingComplete,
+            _that.schemaBackupVersion,
+            _that.lastExchangeRateFetch);
+      case _:
+        throw StateError('Unexpected subclass');
+    }
+  }
+
+  /// A variant of `when` that fallback to returning `null`
+  ///
+  /// It is equivalent to doing:
+  /// ```dart
+  /// switch (sealedClass) {
+  ///   case Subclass(:final field):
+  ///     return ...;
+  ///   case _:
+  ///     return null;
+  /// }
+  /// ```
+
+  @optionalTypeArgs
+  TResult? whenOrNull<TResult extends Object?>(
+    TResult? Function(
+            String homeCurrency,
+            AppTheme theme,
+            ColorSchemeMode colorSchemeMode,
+            String? colorSeed,
+            bool animationsEnabled,
+            DecimalSeparator? numberDecimalSeparator,
+            ThousandsGrouping? numberThousandsGrouping,
+            CurrencySymbolPlacement? currencySymbolPlacement,
+            CurrencySymbolSpacing? currencySymbolSpacing,
+            WeekStart weekStart,
+            TimeFormat? timeFormat,
+            int percentagePrecision,
+            int descriptionMaxLength,
+            BackButtonBehaviour backButtonBehaviour,
+            int lockTimeoutSeconds,
+            String? displayName,
+            bool onboardingComplete,
+            int schemaBackupVersion,
+            int? lastExchangeRateFetch)?
+        $default,
+  ) {
+    final _that = this;
+    switch (_that) {
+      case _AppSettings() when $default != null:
+        return $default(
+            _that.homeCurrency,
+            _that.theme,
+            _that.colorSchemeMode,
+            _that.colorSeed,
+            _that.animationsEnabled,
+            _that.numberDecimalSeparator,
+            _that.numberThousandsGrouping,
+            _that.currencySymbolPlacement,
+            _that.currencySymbolSpacing,
+            _that.weekStart,
+            _that.timeFormat,
+            _that.percentagePrecision,
+            _that.descriptionMaxLength,
+            _that.backButtonBehaviour,
+            _that.lockTimeoutSeconds,
+            _that.displayName,
+            _that.onboardingComplete,
+            _that.schemaBackupVersion,
+            _that.lastExchangeRateFetch);
+      case _:
+        return null;
+    }
+  }
+}
+
+/// @nodoc
+
+class _AppSettings implements AppSettings {
+  const _AppSettings(
+      {this.homeCurrency = 'INR',
+      this.theme = AppTheme.system,
+      this.colorSchemeMode = ColorSchemeMode.dynamic,
+      this.colorSeed,
+      this.animationsEnabled = true,
+      this.numberDecimalSeparator,
+      this.numberThousandsGrouping,
+      this.currencySymbolPlacement,
+      this.currencySymbolSpacing,
+      this.weekStart = WeekStart.monday,
+      this.timeFormat,
+      this.percentagePrecision = 0,
+      this.descriptionMaxLength = 1000,
+      this.backButtonBehaviour = BackButtonBehaviour.ask,
+      this.lockTimeoutSeconds = 0,
+      this.displayName,
+      this.onboardingComplete = false,
+      this.schemaBackupVersion = 1,
+      this.lastExchangeRateFetch});
+
+  /// ISO 4217 home currency code; set during onboarding.
+  @override
+  @JsonKey()
+  final String homeCurrency;
+
+  /// Light/dark/system theme.
+  @override
+  @JsonKey()
+  final AppTheme theme;
+
+  /// Dynamic (wallpaper) or custom seed color scheme.
+  @override
+  @JsonKey()
+  final ColorSchemeMode colorSchemeMode;
+
+  /// Hex seed color for custom color scheme; null when dynamic.
+  @override
+  final String? colorSeed;
+
+  /// Whether in-app animations are enabled.
+  @override
+  @JsonKey()
+  final bool animationsEnabled;
+
+  /// Decimal separator preference.
+  @override
+  final DecimalSeparator? numberDecimalSeparator;
+
+  /// Thousands grouping style.
+  @override
+  final ThousandsGrouping? numberThousandsGrouping;
+
+  /// Currency symbol placement.
+  @override
+  final CurrencySymbolPlacement? currencySymbolPlacement;
+
+  /// Spacing between currency symbol and amount.
+  @override
+  final CurrencySymbolSpacing? currencySymbolSpacing;
+
+  /// Week start day.
+  @override
+  @JsonKey()
+  final WeekStart weekStart;
+
+  /// 12h or 24h time display.
+  @override
+  final TimeFormat? timeFormat;
+
+  /// Percentage display precision (0, 1, or 2).
+  @override
+  @JsonKey()
+  final int percentagePrecision;
+
+  /// Maximum character count for transaction descriptions.
+  @override
+  @JsonKey()
+  final int descriptionMaxLength;
+
+  /// Back button behaviour on unsaved form.
+  @override
+  @JsonKey()
+  final BackButtonBehaviour backButtonBehaviour;
+
+  /// Idle timeout before app-lock; 0 = lock immediately.
+  @override
+  @JsonKey()
+  final int lockTimeoutSeconds;
+
+  /// Optional greeting name shown on the home screen.
+  @override
+  final String? displayName;
+
+  /// Whether onboarding has been completed.
+  @override
+  @JsonKey()
+  final bool onboardingComplete;
+
+  /// Backup format version (TC-054).
+  @override
+  @JsonKey()
+  final int schemaBackupVersion;
+
+  /// Unix epoch of the last successful exchange rate fetch.
+  @override
+  final int? lastExchangeRateFetch;
+
+  /// Create a copy of AppSettings
+  /// with the given fields replaced by the non-null parameter values.
+  @override
+  @JsonKey(includeFromJson: false, includeToJson: false)
+  @pragma('vm:prefer-inline')
+  _$AppSettingsCopyWith<_AppSettings> get copyWith =>
+      __$AppSettingsCopyWithImpl<_AppSettings>(this, _$identity);
+
+  @override
+  bool operator ==(Object other) {
+    return identical(this, other) ||
+        (other.runtimeType == runtimeType &&
+            other is _AppSettings &&
+            (identical(other.homeCurrency, homeCurrency) ||
+                other.homeCurrency == homeCurrency) &&
+            (identical(other.theme, theme) || other.theme == theme) &&
+            (identical(other.colorSchemeMode, colorSchemeMode) ||
+                other.colorSchemeMode == colorSchemeMode) &&
+            (identical(other.colorSeed, colorSeed) ||
+                other.colorSeed == colorSeed) &&
+            (identical(other.animationsEnabled, animationsEnabled) ||
+                other.animationsEnabled == animationsEnabled) &&
+            (identical(other.numberDecimalSeparator, numberDecimalSeparator) ||
+                other.numberDecimalSeparator == numberDecimalSeparator) &&
+            (identical(
+                    other.numberThousandsGrouping, numberThousandsGrouping) ||
+                other.numberThousandsGrouping == numberThousandsGrouping) &&
+            (identical(
+                    other.currencySymbolPlacement, currencySymbolPlacement) ||
+                other.currencySymbolPlacement == currencySymbolPlacement) &&
+            (identical(other.currencySymbolSpacing, currencySymbolSpacing) ||
+                other.currencySymbolSpacing == currencySymbolSpacing) &&
+            (identical(other.weekStart, weekStart) ||
+                other.weekStart == weekStart) &&
+            (identical(other.timeFormat, timeFormat) ||
+                other.timeFormat == timeFormat) &&
+            (identical(other.percentagePrecision, percentagePrecision) ||
+                other.percentagePrecision == percentagePrecision) &&
+            (identical(other.descriptionMaxLength, descriptionMaxLength) ||
+                other.descriptionMaxLength == descriptionMaxLength) &&
+            (identical(other.backButtonBehaviour, backButtonBehaviour) ||
+                other.backButtonBehaviour == backButtonBehaviour) &&
+            (identical(other.lockTimeoutSeconds, lockTimeoutSeconds) ||
+                other.lockTimeoutSeconds == lockTimeoutSeconds) &&
+            (identical(other.displayName, displayName) ||
+                other.displayName == displayName) &&
+            (identical(other.onboardingComplete, onboardingComplete) ||
+                other.onboardingComplete == onboardingComplete) &&
+            (identical(other.schemaBackupVersion, schemaBackupVersion) ||
+                other.schemaBackupVersion == schemaBackupVersion) &&
+            (identical(other.lastExchangeRateFetch, lastExchangeRateFetch) ||
+                other.lastExchangeRateFetch == lastExchangeRateFetch));
+  }
+
+  @override
+  int get hashCode => Object.hashAll([
+        runtimeType,
+        homeCurrency,
+        theme,
+        colorSchemeMode,
+        colorSeed,
+        animationsEnabled,
+        numberDecimalSeparator,
+        numberThousandsGrouping,
+        currencySymbolPlacement,
+        currencySymbolSpacing,
+        weekStart,
+        timeFormat,
+        percentagePrecision,
+        descriptionMaxLength,
+        backButtonBehaviour,
+        lockTimeoutSeconds,
+        displayName,
+        onboardingComplete,
+        schemaBackupVersion,
+        lastExchangeRateFetch
+      ]);
+
+  @override
+  String toString() {
+    return 'AppSettings(homeCurrency: $homeCurrency, theme: $theme, colorSchemeMode: $colorSchemeMode, colorSeed: $colorSeed, animationsEnabled: $animationsEnabled, numberDecimalSeparator: $numberDecimalSeparator, numberThousandsGrouping: $numberThousandsGrouping, currencySymbolPlacement: $currencySymbolPlacement, currencySymbolSpacing: $currencySymbolSpacing, weekStart: $weekStart, timeFormat: $timeFormat, percentagePrecision: $percentagePrecision, descriptionMaxLength: $descriptionMaxLength, backButtonBehaviour: $backButtonBehaviour, lockTimeoutSeconds: $lockTimeoutSeconds, displayName: $displayName, onboardingComplete: $onboardingComplete, schemaBackupVersion: $schemaBackupVersion, lastExchangeRateFetch: $lastExchangeRateFetch)';
+  }
+}
+
+/// @nodoc
+abstract mixin class _$AppSettingsCopyWith<$Res>
+    implements $AppSettingsCopyWith<$Res> {
+  factory _$AppSettingsCopyWith(
+          _AppSettings value, $Res Function(_AppSettings) _then) =
+      __$AppSettingsCopyWithImpl;
+  @override
+  @useResult
+  $Res call(
+      {String homeCurrency,
+      AppTheme theme,
+      ColorSchemeMode colorSchemeMode,
+      String? colorSeed,
+      bool animationsEnabled,
+      DecimalSeparator? numberDecimalSeparator,
+      ThousandsGrouping? numberThousandsGrouping,
+      CurrencySymbolPlacement? currencySymbolPlacement,
+      CurrencySymbolSpacing? currencySymbolSpacing,
+      WeekStart weekStart,
+      TimeFormat? timeFormat,
+      int percentagePrecision,
+      int descriptionMaxLength,
+      BackButtonBehaviour backButtonBehaviour,
+      int lockTimeoutSeconds,
+      String? displayName,
+      bool onboardingComplete,
+      int schemaBackupVersion,
+      int? lastExchangeRateFetch});
+}
+
+/// @nodoc
+class __$AppSettingsCopyWithImpl<$Res> implements _$AppSettingsCopyWith<$Res> {
+  __$AppSettingsCopyWithImpl(this._self, this._then);
+
+  final _AppSettings _self;
+  final $Res Function(_AppSettings) _then;
+
+  /// Create a copy of AppSettings
+  /// with the given fields replaced by the non-null parameter values.
+  @override
+  @pragma('vm:prefer-inline')
+  $Res call({
+    Object? homeCurrency = null,
+    Object? theme = null,
+    Object? colorSchemeMode = null,
+    Object? colorSeed = freezed,
+    Object? animationsEnabled = null,
+    Object? numberDecimalSeparator = freezed,
+    Object? numberThousandsGrouping = freezed,
+    Object? currencySymbolPlacement = freezed,
+    Object? currencySymbolSpacing = freezed,
+    Object? weekStart = null,
+    Object? timeFormat = freezed,
+    Object? percentagePrecision = null,
+    Object? descriptionMaxLength = null,
+    Object? backButtonBehaviour = null,
+    Object? lockTimeoutSeconds = null,
+    Object? displayName = freezed,
+    Object? onboardingComplete = null,
+    Object? schemaBackupVersion = null,
+    Object? lastExchangeRateFetch = freezed,
+  }) {
+    return _then(_AppSettings(
+      homeCurrency: null == homeCurrency
+          ? _self.homeCurrency
+          : homeCurrency // ignore: cast_nullable_to_non_nullable
+              as String,
+      theme: null == theme
+          ? _self.theme
+          : theme // ignore: cast_nullable_to_non_nullable
+              as AppTheme,
+      colorSchemeMode: null == colorSchemeMode
+          ? _self.colorSchemeMode
+          : colorSchemeMode // ignore: cast_nullable_to_non_nullable
+              as ColorSchemeMode,
+      colorSeed: freezed == colorSeed
+          ? _self.colorSeed
+          : colorSeed // ignore: cast_nullable_to_non_nullable
+              as String?,
+      animationsEnabled: null == animationsEnabled
+          ? _self.animationsEnabled
+          : animationsEnabled // ignore: cast_nullable_to_non_nullable
+              as bool,
+      numberDecimalSeparator: freezed == numberDecimalSeparator
+          ? _self.numberDecimalSeparator
+          : numberDecimalSeparator // ignore: cast_nullable_to_non_nullable
+              as DecimalSeparator?,
+      numberThousandsGrouping: freezed == numberThousandsGrouping
+          ? _self.numberThousandsGrouping
+          : numberThousandsGrouping // ignore: cast_nullable_to_non_nullable
+              as ThousandsGrouping?,
+      currencySymbolPlacement: freezed == currencySymbolPlacement
+          ? _self.currencySymbolPlacement
+          : currencySymbolPlacement // ignore: cast_nullable_to_non_nullable
+              as CurrencySymbolPlacement?,
+      currencySymbolSpacing: freezed == currencySymbolSpacing
+          ? _self.currencySymbolSpacing
+          : currencySymbolSpacing // ignore: cast_nullable_to_non_nullable
+              as CurrencySymbolSpacing?,
+      weekStart: null == weekStart
+          ? _self.weekStart
+          : weekStart // ignore: cast_nullable_to_non_nullable
+              as WeekStart,
+      timeFormat: freezed == timeFormat
+          ? _self.timeFormat
+          : timeFormat // ignore: cast_nullable_to_non_nullable
+              as TimeFormat?,
+      percentagePrecision: null == percentagePrecision
+          ? _self.percentagePrecision
+          : percentagePrecision // ignore: cast_nullable_to_non_nullable
+              as int,
+      descriptionMaxLength: null == descriptionMaxLength
+          ? _self.descriptionMaxLength
+          : descriptionMaxLength // ignore: cast_nullable_to_non_nullable
+              as int,
+      backButtonBehaviour: null == backButtonBehaviour
+          ? _self.backButtonBehaviour
+          : backButtonBehaviour // ignore: cast_nullable_to_non_nullable
+              as BackButtonBehaviour,
+      lockTimeoutSeconds: null == lockTimeoutSeconds
+          ? _self.lockTimeoutSeconds
+          : lockTimeoutSeconds // ignore: cast_nullable_to_non_nullable
+              as int,
+      displayName: freezed == displayName
+          ? _self.displayName
+          : displayName // ignore: cast_nullable_to_non_nullable
+              as String?,
+      onboardingComplete: null == onboardingComplete
+          ? _self.onboardingComplete
+          : onboardingComplete // ignore: cast_nullable_to_non_nullable
+              as bool,
+      schemaBackupVersion: null == schemaBackupVersion
+          ? _self.schemaBackupVersion
+          : schemaBackupVersion // ignore: cast_nullable_to_non_nullable
+              as int,
+      lastExchangeRateFetch: freezed == lastExchangeRateFetch
+          ? _self.lastExchangeRateFetch
+          : lastExchangeRateFetch // ignore: cast_nullable_to_non_nullable
+              as int?,
+    ));
+  }
+}
+
+// dart format on

--- a/lib/domain/entities/budget.dart
+++ b/lib/domain/entities/budget.dart
@@ -1,0 +1,57 @@
+// lib/domain/entities/budget.dart
+//
+// Budget domain entity.
+//
+// Budget envelope definition — either a total budget (category_id = null)
+// or a per-category budget for a recurring period.
+
+import 'package:freezed_annotation/freezed_annotation.dart';
+
+part 'budget.freezed.dart';
+
+/// Recurrence horizon for a budget.
+enum BudgetPeriodType {
+  weekly,
+  monthly,
+  quarterly,
+  annual,
+}
+
+/// Immutable domain entity for a budget definition.
+@freezed
+abstract class Budget with _$Budget {
+  const factory Budget({
+    /// UUID v4 stable identifier.
+    required String id,
+
+    /// User label.
+    required String name,
+
+    /// Linked category UUID; null = total (all-categories) budget.
+    String? categoryId,
+
+    /// Budget ceiling in minor units.
+    required int amountMinor,
+
+    /// Home currency of this budget.
+    required String currencyCode,
+
+    /// Recurrence horizon.
+    required BudgetPeriodType periodType,
+
+    /// Number of period units (e.g. periodN=1, periodType=monthly = monthly).
+    @Default(1) int periodN,
+
+    /// Carry unused amount to the next period.
+    @Default(false) bool rollover,
+
+    /// Whether this budget is currently active.
+    @Default(true) bool isActive,
+
+    /// Creation epoch (Unix seconds).
+    required int createdAt,
+
+    /// Last-modified epoch (Unix seconds).
+    required int updatedAt,
+  }) = _Budget;
+}

--- a/lib/domain/entities/budget.freezed.dart
+++ b/lib/domain/entities/budget.freezed.dart
@@ -1,0 +1,633 @@
+// GENERATED CODE - DO NOT MODIFY BY HAND
+// coverage:ignore-file
+// ignore_for_file: type=lint
+// ignore_for_file: unused_element, deprecated_member_use, deprecated_member_use_from_same_package, use_function_type_syntax_for_parameters, unnecessary_const, avoid_init_to_null, invalid_override_different_default_values_named, prefer_expression_function_bodies, annotate_overrides, invalid_annotation_target, unnecessary_question_mark
+
+part of 'budget.dart';
+
+// **************************************************************************
+// FreezedGenerator
+// **************************************************************************
+
+// dart format off
+T _$identity<T>(T value) => value;
+
+/// @nodoc
+mixin _$Budget {
+  /// UUID v4 stable identifier.
+  String get id;
+
+  /// User label.
+  String get name;
+
+  /// Linked category UUID; null = total (all-categories) budget.
+  String? get categoryId;
+
+  /// Budget ceiling in minor units.
+  int get amountMinor;
+
+  /// Home currency of this budget.
+  String get currencyCode;
+
+  /// Recurrence horizon.
+  BudgetPeriodType get periodType;
+
+  /// Number of period units (e.g. periodN=1, periodType=monthly = monthly).
+  int get periodN;
+
+  /// Carry unused amount to the next period.
+  bool get rollover;
+
+  /// Whether this budget is currently active.
+  bool get isActive;
+
+  /// Creation epoch (Unix seconds).
+  int get createdAt;
+
+  /// Last-modified epoch (Unix seconds).
+  int get updatedAt;
+
+  /// Create a copy of Budget
+  /// with the given fields replaced by the non-null parameter values.
+  @JsonKey(includeFromJson: false, includeToJson: false)
+  @pragma('vm:prefer-inline')
+  $BudgetCopyWith<Budget> get copyWith =>
+      _$BudgetCopyWithImpl<Budget>(this as Budget, _$identity);
+
+  @override
+  bool operator ==(Object other) {
+    return identical(this, other) ||
+        (other.runtimeType == runtimeType &&
+            other is Budget &&
+            (identical(other.id, id) || other.id == id) &&
+            (identical(other.name, name) || other.name == name) &&
+            (identical(other.categoryId, categoryId) ||
+                other.categoryId == categoryId) &&
+            (identical(other.amountMinor, amountMinor) ||
+                other.amountMinor == amountMinor) &&
+            (identical(other.currencyCode, currencyCode) ||
+                other.currencyCode == currencyCode) &&
+            (identical(other.periodType, periodType) ||
+                other.periodType == periodType) &&
+            (identical(other.periodN, periodN) || other.periodN == periodN) &&
+            (identical(other.rollover, rollover) ||
+                other.rollover == rollover) &&
+            (identical(other.isActive, isActive) ||
+                other.isActive == isActive) &&
+            (identical(other.createdAt, createdAt) ||
+                other.createdAt == createdAt) &&
+            (identical(other.updatedAt, updatedAt) ||
+                other.updatedAt == updatedAt));
+  }
+
+  @override
+  int get hashCode => Object.hash(
+      runtimeType,
+      id,
+      name,
+      categoryId,
+      amountMinor,
+      currencyCode,
+      periodType,
+      periodN,
+      rollover,
+      isActive,
+      createdAt,
+      updatedAt);
+
+  @override
+  String toString() {
+    return 'Budget(id: $id, name: $name, categoryId: $categoryId, amountMinor: $amountMinor, currencyCode: $currencyCode, periodType: $periodType, periodN: $periodN, rollover: $rollover, isActive: $isActive, createdAt: $createdAt, updatedAt: $updatedAt)';
+  }
+}
+
+/// @nodoc
+abstract mixin class $BudgetCopyWith<$Res> {
+  factory $BudgetCopyWith(Budget value, $Res Function(Budget) _then) =
+      _$BudgetCopyWithImpl;
+  @useResult
+  $Res call(
+      {String id,
+      String name,
+      String? categoryId,
+      int amountMinor,
+      String currencyCode,
+      BudgetPeriodType periodType,
+      int periodN,
+      bool rollover,
+      bool isActive,
+      int createdAt,
+      int updatedAt});
+}
+
+/// @nodoc
+class _$BudgetCopyWithImpl<$Res> implements $BudgetCopyWith<$Res> {
+  _$BudgetCopyWithImpl(this._self, this._then);
+
+  final Budget _self;
+  final $Res Function(Budget) _then;
+
+  /// Create a copy of Budget
+  /// with the given fields replaced by the non-null parameter values.
+  @pragma('vm:prefer-inline')
+  @override
+  $Res call({
+    Object? id = null,
+    Object? name = null,
+    Object? categoryId = freezed,
+    Object? amountMinor = null,
+    Object? currencyCode = null,
+    Object? periodType = null,
+    Object? periodN = null,
+    Object? rollover = null,
+    Object? isActive = null,
+    Object? createdAt = null,
+    Object? updatedAt = null,
+  }) {
+    return _then(_self.copyWith(
+      id: null == id
+          ? _self.id
+          : id // ignore: cast_nullable_to_non_nullable
+              as String,
+      name: null == name
+          ? _self.name
+          : name // ignore: cast_nullable_to_non_nullable
+              as String,
+      categoryId: freezed == categoryId
+          ? _self.categoryId
+          : categoryId // ignore: cast_nullable_to_non_nullable
+              as String?,
+      amountMinor: null == amountMinor
+          ? _self.amountMinor
+          : amountMinor // ignore: cast_nullable_to_non_nullable
+              as int,
+      currencyCode: null == currencyCode
+          ? _self.currencyCode
+          : currencyCode // ignore: cast_nullable_to_non_nullable
+              as String,
+      periodType: null == periodType
+          ? _self.periodType
+          : periodType // ignore: cast_nullable_to_non_nullable
+              as BudgetPeriodType,
+      periodN: null == periodN
+          ? _self.periodN
+          : periodN // ignore: cast_nullable_to_non_nullable
+              as int,
+      rollover: null == rollover
+          ? _self.rollover
+          : rollover // ignore: cast_nullable_to_non_nullable
+              as bool,
+      isActive: null == isActive
+          ? _self.isActive
+          : isActive // ignore: cast_nullable_to_non_nullable
+              as bool,
+      createdAt: null == createdAt
+          ? _self.createdAt
+          : createdAt // ignore: cast_nullable_to_non_nullable
+              as int,
+      updatedAt: null == updatedAt
+          ? _self.updatedAt
+          : updatedAt // ignore: cast_nullable_to_non_nullable
+              as int,
+    ));
+  }
+}
+
+/// Adds pattern-matching-related methods to [Budget].
+extension BudgetPatterns on Budget {
+  /// A variant of `map` that fallback to returning `orElse`.
+  ///
+  /// It is equivalent to doing:
+  /// ```dart
+  /// switch (sealedClass) {
+  ///   case final Subclass value:
+  ///     return ...;
+  ///   case _:
+  ///     return orElse();
+  /// }
+  /// ```
+
+  @optionalTypeArgs
+  TResult maybeMap<TResult extends Object?>(
+    TResult Function(_Budget value)? $default, {
+    required TResult orElse(),
+  }) {
+    final _that = this;
+    switch (_that) {
+      case _Budget() when $default != null:
+        return $default(_that);
+      case _:
+        return orElse();
+    }
+  }
+
+  /// A `switch`-like method, using callbacks.
+  ///
+  /// Callbacks receives the raw object, upcasted.
+  /// It is equivalent to doing:
+  /// ```dart
+  /// switch (sealedClass) {
+  ///   case final Subclass value:
+  ///     return ...;
+  ///   case final Subclass2 value:
+  ///     return ...;
+  /// }
+  /// ```
+
+  @optionalTypeArgs
+  TResult map<TResult extends Object?>(
+    TResult Function(_Budget value) $default,
+  ) {
+    final _that = this;
+    switch (_that) {
+      case _Budget():
+        return $default(_that);
+      case _:
+        throw StateError('Unexpected subclass');
+    }
+  }
+
+  /// A variant of `map` that fallback to returning `null`.
+  ///
+  /// It is equivalent to doing:
+  /// ```dart
+  /// switch (sealedClass) {
+  ///   case final Subclass value:
+  ///     return ...;
+  ///   case _:
+  ///     return null;
+  /// }
+  /// ```
+
+  @optionalTypeArgs
+  TResult? mapOrNull<TResult extends Object?>(
+    TResult? Function(_Budget value)? $default,
+  ) {
+    final _that = this;
+    switch (_that) {
+      case _Budget() when $default != null:
+        return $default(_that);
+      case _:
+        return null;
+    }
+  }
+
+  /// A variant of `when` that fallback to an `orElse` callback.
+  ///
+  /// It is equivalent to doing:
+  /// ```dart
+  /// switch (sealedClass) {
+  ///   case Subclass(:final field):
+  ///     return ...;
+  ///   case _:
+  ///     return orElse();
+  /// }
+  /// ```
+
+  @optionalTypeArgs
+  TResult maybeWhen<TResult extends Object?>(
+    TResult Function(
+            String id,
+            String name,
+            String? categoryId,
+            int amountMinor,
+            String currencyCode,
+            BudgetPeriodType periodType,
+            int periodN,
+            bool rollover,
+            bool isActive,
+            int createdAt,
+            int updatedAt)?
+        $default, {
+    required TResult orElse(),
+  }) {
+    final _that = this;
+    switch (_that) {
+      case _Budget() when $default != null:
+        return $default(
+            _that.id,
+            _that.name,
+            _that.categoryId,
+            _that.amountMinor,
+            _that.currencyCode,
+            _that.periodType,
+            _that.periodN,
+            _that.rollover,
+            _that.isActive,
+            _that.createdAt,
+            _that.updatedAt);
+      case _:
+        return orElse();
+    }
+  }
+
+  /// A `switch`-like method, using callbacks.
+  ///
+  /// As opposed to `map`, this offers destructuring.
+  /// It is equivalent to doing:
+  /// ```dart
+  /// switch (sealedClass) {
+  ///   case Subclass(:final field):
+  ///     return ...;
+  ///   case Subclass2(:final field2):
+  ///     return ...;
+  /// }
+  /// ```
+
+  @optionalTypeArgs
+  TResult when<TResult extends Object?>(
+    TResult Function(
+            String id,
+            String name,
+            String? categoryId,
+            int amountMinor,
+            String currencyCode,
+            BudgetPeriodType periodType,
+            int periodN,
+            bool rollover,
+            bool isActive,
+            int createdAt,
+            int updatedAt)
+        $default,
+  ) {
+    final _that = this;
+    switch (_that) {
+      case _Budget():
+        return $default(
+            _that.id,
+            _that.name,
+            _that.categoryId,
+            _that.amountMinor,
+            _that.currencyCode,
+            _that.periodType,
+            _that.periodN,
+            _that.rollover,
+            _that.isActive,
+            _that.createdAt,
+            _that.updatedAt);
+      case _:
+        throw StateError('Unexpected subclass');
+    }
+  }
+
+  /// A variant of `when` that fallback to returning `null`
+  ///
+  /// It is equivalent to doing:
+  /// ```dart
+  /// switch (sealedClass) {
+  ///   case Subclass(:final field):
+  ///     return ...;
+  ///   case _:
+  ///     return null;
+  /// }
+  /// ```
+
+  @optionalTypeArgs
+  TResult? whenOrNull<TResult extends Object?>(
+    TResult? Function(
+            String id,
+            String name,
+            String? categoryId,
+            int amountMinor,
+            String currencyCode,
+            BudgetPeriodType periodType,
+            int periodN,
+            bool rollover,
+            bool isActive,
+            int createdAt,
+            int updatedAt)?
+        $default,
+  ) {
+    final _that = this;
+    switch (_that) {
+      case _Budget() when $default != null:
+        return $default(
+            _that.id,
+            _that.name,
+            _that.categoryId,
+            _that.amountMinor,
+            _that.currencyCode,
+            _that.periodType,
+            _that.periodN,
+            _that.rollover,
+            _that.isActive,
+            _that.createdAt,
+            _that.updatedAt);
+      case _:
+        return null;
+    }
+  }
+}
+
+/// @nodoc
+
+class _Budget implements Budget {
+  const _Budget(
+      {required this.id,
+      required this.name,
+      this.categoryId,
+      required this.amountMinor,
+      required this.currencyCode,
+      required this.periodType,
+      this.periodN = 1,
+      this.rollover = false,
+      this.isActive = true,
+      required this.createdAt,
+      required this.updatedAt});
+
+  /// UUID v4 stable identifier.
+  @override
+  final String id;
+
+  /// User label.
+  @override
+  final String name;
+
+  /// Linked category UUID; null = total (all-categories) budget.
+  @override
+  final String? categoryId;
+
+  /// Budget ceiling in minor units.
+  @override
+  final int amountMinor;
+
+  /// Home currency of this budget.
+  @override
+  final String currencyCode;
+
+  /// Recurrence horizon.
+  @override
+  final BudgetPeriodType periodType;
+
+  /// Number of period units (e.g. periodN=1, periodType=monthly = monthly).
+  @override
+  @JsonKey()
+  final int periodN;
+
+  /// Carry unused amount to the next period.
+  @override
+  @JsonKey()
+  final bool rollover;
+
+  /// Whether this budget is currently active.
+  @override
+  @JsonKey()
+  final bool isActive;
+
+  /// Creation epoch (Unix seconds).
+  @override
+  final int createdAt;
+
+  /// Last-modified epoch (Unix seconds).
+  @override
+  final int updatedAt;
+
+  /// Create a copy of Budget
+  /// with the given fields replaced by the non-null parameter values.
+  @override
+  @JsonKey(includeFromJson: false, includeToJson: false)
+  @pragma('vm:prefer-inline')
+  _$BudgetCopyWith<_Budget> get copyWith =>
+      __$BudgetCopyWithImpl<_Budget>(this, _$identity);
+
+  @override
+  bool operator ==(Object other) {
+    return identical(this, other) ||
+        (other.runtimeType == runtimeType &&
+            other is _Budget &&
+            (identical(other.id, id) || other.id == id) &&
+            (identical(other.name, name) || other.name == name) &&
+            (identical(other.categoryId, categoryId) ||
+                other.categoryId == categoryId) &&
+            (identical(other.amountMinor, amountMinor) ||
+                other.amountMinor == amountMinor) &&
+            (identical(other.currencyCode, currencyCode) ||
+                other.currencyCode == currencyCode) &&
+            (identical(other.periodType, periodType) ||
+                other.periodType == periodType) &&
+            (identical(other.periodN, periodN) || other.periodN == periodN) &&
+            (identical(other.rollover, rollover) ||
+                other.rollover == rollover) &&
+            (identical(other.isActive, isActive) ||
+                other.isActive == isActive) &&
+            (identical(other.createdAt, createdAt) ||
+                other.createdAt == createdAt) &&
+            (identical(other.updatedAt, updatedAt) ||
+                other.updatedAt == updatedAt));
+  }
+
+  @override
+  int get hashCode => Object.hash(
+      runtimeType,
+      id,
+      name,
+      categoryId,
+      amountMinor,
+      currencyCode,
+      periodType,
+      periodN,
+      rollover,
+      isActive,
+      createdAt,
+      updatedAt);
+
+  @override
+  String toString() {
+    return 'Budget(id: $id, name: $name, categoryId: $categoryId, amountMinor: $amountMinor, currencyCode: $currencyCode, periodType: $periodType, periodN: $periodN, rollover: $rollover, isActive: $isActive, createdAt: $createdAt, updatedAt: $updatedAt)';
+  }
+}
+
+/// @nodoc
+abstract mixin class _$BudgetCopyWith<$Res> implements $BudgetCopyWith<$Res> {
+  factory _$BudgetCopyWith(_Budget value, $Res Function(_Budget) _then) =
+      __$BudgetCopyWithImpl;
+  @override
+  @useResult
+  $Res call(
+      {String id,
+      String name,
+      String? categoryId,
+      int amountMinor,
+      String currencyCode,
+      BudgetPeriodType periodType,
+      int periodN,
+      bool rollover,
+      bool isActive,
+      int createdAt,
+      int updatedAt});
+}
+
+/// @nodoc
+class __$BudgetCopyWithImpl<$Res> implements _$BudgetCopyWith<$Res> {
+  __$BudgetCopyWithImpl(this._self, this._then);
+
+  final _Budget _self;
+  final $Res Function(_Budget) _then;
+
+  /// Create a copy of Budget
+  /// with the given fields replaced by the non-null parameter values.
+  @override
+  @pragma('vm:prefer-inline')
+  $Res call({
+    Object? id = null,
+    Object? name = null,
+    Object? categoryId = freezed,
+    Object? amountMinor = null,
+    Object? currencyCode = null,
+    Object? periodType = null,
+    Object? periodN = null,
+    Object? rollover = null,
+    Object? isActive = null,
+    Object? createdAt = null,
+    Object? updatedAt = null,
+  }) {
+    return _then(_Budget(
+      id: null == id
+          ? _self.id
+          : id // ignore: cast_nullable_to_non_nullable
+              as String,
+      name: null == name
+          ? _self.name
+          : name // ignore: cast_nullable_to_non_nullable
+              as String,
+      categoryId: freezed == categoryId
+          ? _self.categoryId
+          : categoryId // ignore: cast_nullable_to_non_nullable
+              as String?,
+      amountMinor: null == amountMinor
+          ? _self.amountMinor
+          : amountMinor // ignore: cast_nullable_to_non_nullable
+              as int,
+      currencyCode: null == currencyCode
+          ? _self.currencyCode
+          : currencyCode // ignore: cast_nullable_to_non_nullable
+              as String,
+      periodType: null == periodType
+          ? _self.periodType
+          : periodType // ignore: cast_nullable_to_non_nullable
+              as BudgetPeriodType,
+      periodN: null == periodN
+          ? _self.periodN
+          : periodN // ignore: cast_nullable_to_non_nullable
+              as int,
+      rollover: null == rollover
+          ? _self.rollover
+          : rollover // ignore: cast_nullable_to_non_nullable
+              as bool,
+      isActive: null == isActive
+          ? _self.isActive
+          : isActive // ignore: cast_nullable_to_non_nullable
+              as bool,
+      createdAt: null == createdAt
+          ? _self.createdAt
+          : createdAt // ignore: cast_nullable_to_non_nullable
+              as int,
+      updatedAt: null == updatedAt
+          ? _self.updatedAt
+          : updatedAt // ignore: cast_nullable_to_non_nullable
+              as int,
+    ));
+  }
+}
+
+// dart format on

--- a/lib/domain/entities/budget_period.dart
+++ b/lib/domain/entities/budget_period.dart
@@ -1,0 +1,38 @@
+// lib/domain/entities/budget_period.dart
+//
+// BudgetPeriod domain entity.
+//
+// Materialized period instance for a Budget. Computed values (spent,
+// remaining) are derived at query time from entries; carriedOverMinor is the
+// only stored rolled-over value.
+
+import 'package:freezed_annotation/freezed_annotation.dart';
+
+part 'budget_period.freezed.dart';
+
+/// Immutable domain entity for a materialized budget period.
+@freezed
+abstract class BudgetPeriod with _$BudgetPeriod {
+  const factory BudgetPeriod({
+    /// UUID v4 stable identifier.
+    required String id,
+
+    /// Parent budget UUID.
+    required String budgetId,
+
+    /// Period start epoch (inclusive, Unix seconds).
+    required int periodStart,
+
+    /// Period end epoch (exclusive, Unix seconds).
+    required int periodEnd,
+
+    /// Effective ceiling including carryover (minor units).
+    required int budgetedMinor,
+
+    /// Rolled-over amount from the previous period (minor units).
+    @Default(0) int carriedOverMinor,
+
+    /// Creation epoch (Unix seconds).
+    required int createdAt,
+  }) = _BudgetPeriod;
+}

--- a/lib/domain/entities/budget_period.freezed.dart
+++ b/lib/domain/entities/budget_period.freezed.dart
@@ -1,0 +1,486 @@
+// GENERATED CODE - DO NOT MODIFY BY HAND
+// coverage:ignore-file
+// ignore_for_file: type=lint
+// ignore_for_file: unused_element, deprecated_member_use, deprecated_member_use_from_same_package, use_function_type_syntax_for_parameters, unnecessary_const, avoid_init_to_null, invalid_override_different_default_values_named, prefer_expression_function_bodies, annotate_overrides, invalid_annotation_target, unnecessary_question_mark
+
+part of 'budget_period.dart';
+
+// **************************************************************************
+// FreezedGenerator
+// **************************************************************************
+
+// dart format off
+T _$identity<T>(T value) => value;
+
+/// @nodoc
+mixin _$BudgetPeriod {
+  /// UUID v4 stable identifier.
+  String get id;
+
+  /// Parent budget UUID.
+  String get budgetId;
+
+  /// Period start epoch (inclusive, Unix seconds).
+  int get periodStart;
+
+  /// Period end epoch (exclusive, Unix seconds).
+  int get periodEnd;
+
+  /// Effective ceiling including carryover (minor units).
+  int get budgetedMinor;
+
+  /// Rolled-over amount from the previous period (minor units).
+  int get carriedOverMinor;
+
+  /// Creation epoch (Unix seconds).
+  int get createdAt;
+
+  /// Create a copy of BudgetPeriod
+  /// with the given fields replaced by the non-null parameter values.
+  @JsonKey(includeFromJson: false, includeToJson: false)
+  @pragma('vm:prefer-inline')
+  $BudgetPeriodCopyWith<BudgetPeriod> get copyWith =>
+      _$BudgetPeriodCopyWithImpl<BudgetPeriod>(
+          this as BudgetPeriod, _$identity);
+
+  @override
+  bool operator ==(Object other) {
+    return identical(this, other) ||
+        (other.runtimeType == runtimeType &&
+            other is BudgetPeriod &&
+            (identical(other.id, id) || other.id == id) &&
+            (identical(other.budgetId, budgetId) ||
+                other.budgetId == budgetId) &&
+            (identical(other.periodStart, periodStart) ||
+                other.periodStart == periodStart) &&
+            (identical(other.periodEnd, periodEnd) ||
+                other.periodEnd == periodEnd) &&
+            (identical(other.budgetedMinor, budgetedMinor) ||
+                other.budgetedMinor == budgetedMinor) &&
+            (identical(other.carriedOverMinor, carriedOverMinor) ||
+                other.carriedOverMinor == carriedOverMinor) &&
+            (identical(other.createdAt, createdAt) ||
+                other.createdAt == createdAt));
+  }
+
+  @override
+  int get hashCode => Object.hash(runtimeType, id, budgetId, periodStart,
+      periodEnd, budgetedMinor, carriedOverMinor, createdAt);
+
+  @override
+  String toString() {
+    return 'BudgetPeriod(id: $id, budgetId: $budgetId, periodStart: $periodStart, periodEnd: $periodEnd, budgetedMinor: $budgetedMinor, carriedOverMinor: $carriedOverMinor, createdAt: $createdAt)';
+  }
+}
+
+/// @nodoc
+abstract mixin class $BudgetPeriodCopyWith<$Res> {
+  factory $BudgetPeriodCopyWith(
+          BudgetPeriod value, $Res Function(BudgetPeriod) _then) =
+      _$BudgetPeriodCopyWithImpl;
+  @useResult
+  $Res call(
+      {String id,
+      String budgetId,
+      int periodStart,
+      int periodEnd,
+      int budgetedMinor,
+      int carriedOverMinor,
+      int createdAt});
+}
+
+/// @nodoc
+class _$BudgetPeriodCopyWithImpl<$Res> implements $BudgetPeriodCopyWith<$Res> {
+  _$BudgetPeriodCopyWithImpl(this._self, this._then);
+
+  final BudgetPeriod _self;
+  final $Res Function(BudgetPeriod) _then;
+
+  /// Create a copy of BudgetPeriod
+  /// with the given fields replaced by the non-null parameter values.
+  @pragma('vm:prefer-inline')
+  @override
+  $Res call({
+    Object? id = null,
+    Object? budgetId = null,
+    Object? periodStart = null,
+    Object? periodEnd = null,
+    Object? budgetedMinor = null,
+    Object? carriedOverMinor = null,
+    Object? createdAt = null,
+  }) {
+    return _then(_self.copyWith(
+      id: null == id
+          ? _self.id
+          : id // ignore: cast_nullable_to_non_nullable
+              as String,
+      budgetId: null == budgetId
+          ? _self.budgetId
+          : budgetId // ignore: cast_nullable_to_non_nullable
+              as String,
+      periodStart: null == periodStart
+          ? _self.periodStart
+          : periodStart // ignore: cast_nullable_to_non_nullable
+              as int,
+      periodEnd: null == periodEnd
+          ? _self.periodEnd
+          : periodEnd // ignore: cast_nullable_to_non_nullable
+              as int,
+      budgetedMinor: null == budgetedMinor
+          ? _self.budgetedMinor
+          : budgetedMinor // ignore: cast_nullable_to_non_nullable
+              as int,
+      carriedOverMinor: null == carriedOverMinor
+          ? _self.carriedOverMinor
+          : carriedOverMinor // ignore: cast_nullable_to_non_nullable
+              as int,
+      createdAt: null == createdAt
+          ? _self.createdAt
+          : createdAt // ignore: cast_nullable_to_non_nullable
+              as int,
+    ));
+  }
+}
+
+/// Adds pattern-matching-related methods to [BudgetPeriod].
+extension BudgetPeriodPatterns on BudgetPeriod {
+  /// A variant of `map` that fallback to returning `orElse`.
+  ///
+  /// It is equivalent to doing:
+  /// ```dart
+  /// switch (sealedClass) {
+  ///   case final Subclass value:
+  ///     return ...;
+  ///   case _:
+  ///     return orElse();
+  /// }
+  /// ```
+
+  @optionalTypeArgs
+  TResult maybeMap<TResult extends Object?>(
+    TResult Function(_BudgetPeriod value)? $default, {
+    required TResult orElse(),
+  }) {
+    final _that = this;
+    switch (_that) {
+      case _BudgetPeriod() when $default != null:
+        return $default(_that);
+      case _:
+        return orElse();
+    }
+  }
+
+  /// A `switch`-like method, using callbacks.
+  ///
+  /// Callbacks receives the raw object, upcasted.
+  /// It is equivalent to doing:
+  /// ```dart
+  /// switch (sealedClass) {
+  ///   case final Subclass value:
+  ///     return ...;
+  ///   case final Subclass2 value:
+  ///     return ...;
+  /// }
+  /// ```
+
+  @optionalTypeArgs
+  TResult map<TResult extends Object?>(
+    TResult Function(_BudgetPeriod value) $default,
+  ) {
+    final _that = this;
+    switch (_that) {
+      case _BudgetPeriod():
+        return $default(_that);
+      case _:
+        throw StateError('Unexpected subclass');
+    }
+  }
+
+  /// A variant of `map` that fallback to returning `null`.
+  ///
+  /// It is equivalent to doing:
+  /// ```dart
+  /// switch (sealedClass) {
+  ///   case final Subclass value:
+  ///     return ...;
+  ///   case _:
+  ///     return null;
+  /// }
+  /// ```
+
+  @optionalTypeArgs
+  TResult? mapOrNull<TResult extends Object?>(
+    TResult? Function(_BudgetPeriod value)? $default,
+  ) {
+    final _that = this;
+    switch (_that) {
+      case _BudgetPeriod() when $default != null:
+        return $default(_that);
+      case _:
+        return null;
+    }
+  }
+
+  /// A variant of `when` that fallback to an `orElse` callback.
+  ///
+  /// It is equivalent to doing:
+  /// ```dart
+  /// switch (sealedClass) {
+  ///   case Subclass(:final field):
+  ///     return ...;
+  ///   case _:
+  ///     return orElse();
+  /// }
+  /// ```
+
+  @optionalTypeArgs
+  TResult maybeWhen<TResult extends Object?>(
+    TResult Function(String id, String budgetId, int periodStart, int periodEnd,
+            int budgetedMinor, int carriedOverMinor, int createdAt)?
+        $default, {
+    required TResult orElse(),
+  }) {
+    final _that = this;
+    switch (_that) {
+      case _BudgetPeriod() when $default != null:
+        return $default(
+            _that.id,
+            _that.budgetId,
+            _that.periodStart,
+            _that.periodEnd,
+            _that.budgetedMinor,
+            _that.carriedOverMinor,
+            _that.createdAt);
+      case _:
+        return orElse();
+    }
+  }
+
+  /// A `switch`-like method, using callbacks.
+  ///
+  /// As opposed to `map`, this offers destructuring.
+  /// It is equivalent to doing:
+  /// ```dart
+  /// switch (sealedClass) {
+  ///   case Subclass(:final field):
+  ///     return ...;
+  ///   case Subclass2(:final field2):
+  ///     return ...;
+  /// }
+  /// ```
+
+  @optionalTypeArgs
+  TResult when<TResult extends Object?>(
+    TResult Function(String id, String budgetId, int periodStart, int periodEnd,
+            int budgetedMinor, int carriedOverMinor, int createdAt)
+        $default,
+  ) {
+    final _that = this;
+    switch (_that) {
+      case _BudgetPeriod():
+        return $default(
+            _that.id,
+            _that.budgetId,
+            _that.periodStart,
+            _that.periodEnd,
+            _that.budgetedMinor,
+            _that.carriedOverMinor,
+            _that.createdAt);
+      case _:
+        throw StateError('Unexpected subclass');
+    }
+  }
+
+  /// A variant of `when` that fallback to returning `null`
+  ///
+  /// It is equivalent to doing:
+  /// ```dart
+  /// switch (sealedClass) {
+  ///   case Subclass(:final field):
+  ///     return ...;
+  ///   case _:
+  ///     return null;
+  /// }
+  /// ```
+
+  @optionalTypeArgs
+  TResult? whenOrNull<TResult extends Object?>(
+    TResult? Function(
+            String id,
+            String budgetId,
+            int periodStart,
+            int periodEnd,
+            int budgetedMinor,
+            int carriedOverMinor,
+            int createdAt)?
+        $default,
+  ) {
+    final _that = this;
+    switch (_that) {
+      case _BudgetPeriod() when $default != null:
+        return $default(
+            _that.id,
+            _that.budgetId,
+            _that.periodStart,
+            _that.periodEnd,
+            _that.budgetedMinor,
+            _that.carriedOverMinor,
+            _that.createdAt);
+      case _:
+        return null;
+    }
+  }
+}
+
+/// @nodoc
+
+class _BudgetPeriod implements BudgetPeriod {
+  const _BudgetPeriod(
+      {required this.id,
+      required this.budgetId,
+      required this.periodStart,
+      required this.periodEnd,
+      required this.budgetedMinor,
+      this.carriedOverMinor = 0,
+      required this.createdAt});
+
+  /// UUID v4 stable identifier.
+  @override
+  final String id;
+
+  /// Parent budget UUID.
+  @override
+  final String budgetId;
+
+  /// Period start epoch (inclusive, Unix seconds).
+  @override
+  final int periodStart;
+
+  /// Period end epoch (exclusive, Unix seconds).
+  @override
+  final int periodEnd;
+
+  /// Effective ceiling including carryover (minor units).
+  @override
+  final int budgetedMinor;
+
+  /// Rolled-over amount from the previous period (minor units).
+  @override
+  @JsonKey()
+  final int carriedOverMinor;
+
+  /// Creation epoch (Unix seconds).
+  @override
+  final int createdAt;
+
+  /// Create a copy of BudgetPeriod
+  /// with the given fields replaced by the non-null parameter values.
+  @override
+  @JsonKey(includeFromJson: false, includeToJson: false)
+  @pragma('vm:prefer-inline')
+  _$BudgetPeriodCopyWith<_BudgetPeriod> get copyWith =>
+      __$BudgetPeriodCopyWithImpl<_BudgetPeriod>(this, _$identity);
+
+  @override
+  bool operator ==(Object other) {
+    return identical(this, other) ||
+        (other.runtimeType == runtimeType &&
+            other is _BudgetPeriod &&
+            (identical(other.id, id) || other.id == id) &&
+            (identical(other.budgetId, budgetId) ||
+                other.budgetId == budgetId) &&
+            (identical(other.periodStart, periodStart) ||
+                other.periodStart == periodStart) &&
+            (identical(other.periodEnd, periodEnd) ||
+                other.periodEnd == periodEnd) &&
+            (identical(other.budgetedMinor, budgetedMinor) ||
+                other.budgetedMinor == budgetedMinor) &&
+            (identical(other.carriedOverMinor, carriedOverMinor) ||
+                other.carriedOverMinor == carriedOverMinor) &&
+            (identical(other.createdAt, createdAt) ||
+                other.createdAt == createdAt));
+  }
+
+  @override
+  int get hashCode => Object.hash(runtimeType, id, budgetId, periodStart,
+      periodEnd, budgetedMinor, carriedOverMinor, createdAt);
+
+  @override
+  String toString() {
+    return 'BudgetPeriod(id: $id, budgetId: $budgetId, periodStart: $periodStart, periodEnd: $periodEnd, budgetedMinor: $budgetedMinor, carriedOverMinor: $carriedOverMinor, createdAt: $createdAt)';
+  }
+}
+
+/// @nodoc
+abstract mixin class _$BudgetPeriodCopyWith<$Res>
+    implements $BudgetPeriodCopyWith<$Res> {
+  factory _$BudgetPeriodCopyWith(
+          _BudgetPeriod value, $Res Function(_BudgetPeriod) _then) =
+      __$BudgetPeriodCopyWithImpl;
+  @override
+  @useResult
+  $Res call(
+      {String id,
+      String budgetId,
+      int periodStart,
+      int periodEnd,
+      int budgetedMinor,
+      int carriedOverMinor,
+      int createdAt});
+}
+
+/// @nodoc
+class __$BudgetPeriodCopyWithImpl<$Res>
+    implements _$BudgetPeriodCopyWith<$Res> {
+  __$BudgetPeriodCopyWithImpl(this._self, this._then);
+
+  final _BudgetPeriod _self;
+  final $Res Function(_BudgetPeriod) _then;
+
+  /// Create a copy of BudgetPeriod
+  /// with the given fields replaced by the non-null parameter values.
+  @override
+  @pragma('vm:prefer-inline')
+  $Res call({
+    Object? id = null,
+    Object? budgetId = null,
+    Object? periodStart = null,
+    Object? periodEnd = null,
+    Object? budgetedMinor = null,
+    Object? carriedOverMinor = null,
+    Object? createdAt = null,
+  }) {
+    return _then(_BudgetPeriod(
+      id: null == id
+          ? _self.id
+          : id // ignore: cast_nullable_to_non_nullable
+              as String,
+      budgetId: null == budgetId
+          ? _self.budgetId
+          : budgetId // ignore: cast_nullable_to_non_nullable
+              as String,
+      periodStart: null == periodStart
+          ? _self.periodStart
+          : periodStart // ignore: cast_nullable_to_non_nullable
+              as int,
+      periodEnd: null == periodEnd
+          ? _self.periodEnd
+          : periodEnd // ignore: cast_nullable_to_non_nullable
+              as int,
+      budgetedMinor: null == budgetedMinor
+          ? _self.budgetedMinor
+          : budgetedMinor // ignore: cast_nullable_to_non_nullable
+              as int,
+      carriedOverMinor: null == carriedOverMinor
+          ? _self.carriedOverMinor
+          : carriedOverMinor // ignore: cast_nullable_to_non_nullable
+              as int,
+      createdAt: null == createdAt
+          ? _self.createdAt
+          : createdAt // ignore: cast_nullable_to_non_nullable
+              as int,
+    ));
+  }
+}
+
+// dart format on

--- a/lib/domain/entities/category.dart
+++ b/lib/domain/entities/category.dart
@@ -1,0 +1,56 @@
+// lib/domain/entities/category.dart
+//
+// Category domain entity.
+//
+// Two-level hierarchy (parent/child). Income and expense trees are separate.
+// System-protected categories (Balance Adjustment, Fees & Charges) cannot be
+// deleted. parent_id = null means top-level (root) category.
+
+import 'package:freezed_annotation/freezed_annotation.dart';
+
+part 'category.freezed.dart';
+
+/// Which category tree this category belongs to.
+enum CategoryTreeType {
+  income,
+  expense,
+}
+
+/// Immutable domain entity for a transaction category.
+@freezed
+abstract class Category with _$Category {
+  const factory Category({
+    /// UUID v4 stable identifier.
+    required String id,
+
+    /// Parent category UUID; null for root categories.
+    String? parentId,
+
+    /// Income or expense tree.
+    required CategoryTreeType treeType,
+
+    /// Display name; unique within tree/parent (case-insensitive, incl. soft-deleted).
+    required String name,
+
+    /// Material Symbols icon identifier.
+    required String iconRef,
+
+    /// Soft-delete flag.
+    @Default(false) bool isDeleted,
+
+    /// Soft-delete epoch (Unix seconds); set when [isDeleted] becomes true.
+    int? deletedAt,
+
+    /// True for BAI/BAE and "Balance Adjustment" parent; blocks deletion.
+    @Default(false) bool isProtected,
+
+    /// Manual sort order; null = alphabetical (v1 default).
+    int? sortOrder,
+
+    /// Creation epoch (Unix seconds).
+    required int createdAt,
+
+    /// Last-modified epoch (Unix seconds).
+    required int updatedAt,
+  }) = _Category;
+}

--- a/lib/domain/entities/category.freezed.dart
+++ b/lib/domain/entities/category.freezed.dart
@@ -1,0 +1,633 @@
+// GENERATED CODE - DO NOT MODIFY BY HAND
+// coverage:ignore-file
+// ignore_for_file: type=lint
+// ignore_for_file: unused_element, deprecated_member_use, deprecated_member_use_from_same_package, use_function_type_syntax_for_parameters, unnecessary_const, avoid_init_to_null, invalid_override_different_default_values_named, prefer_expression_function_bodies, annotate_overrides, invalid_annotation_target, unnecessary_question_mark
+
+part of 'category.dart';
+
+// **************************************************************************
+// FreezedGenerator
+// **************************************************************************
+
+// dart format off
+T _$identity<T>(T value) => value;
+
+/// @nodoc
+mixin _$Category {
+  /// UUID v4 stable identifier.
+  String get id;
+
+  /// Parent category UUID; null for root categories.
+  String? get parentId;
+
+  /// Income or expense tree.
+  CategoryTreeType get treeType;
+
+  /// Display name; unique within tree/parent (case-insensitive, incl. soft-deleted).
+  String get name;
+
+  /// Material Symbols icon identifier.
+  String get iconRef;
+
+  /// Soft-delete flag.
+  bool get isDeleted;
+
+  /// Soft-delete epoch (Unix seconds); set when [isDeleted] becomes true.
+  int? get deletedAt;
+
+  /// True for BAI/BAE and "Balance Adjustment" parent; blocks deletion.
+  bool get isProtected;
+
+  /// Manual sort order; null = alphabetical (v1 default).
+  int? get sortOrder;
+
+  /// Creation epoch (Unix seconds).
+  int get createdAt;
+
+  /// Last-modified epoch (Unix seconds).
+  int get updatedAt;
+
+  /// Create a copy of Category
+  /// with the given fields replaced by the non-null parameter values.
+  @JsonKey(includeFromJson: false, includeToJson: false)
+  @pragma('vm:prefer-inline')
+  $CategoryCopyWith<Category> get copyWith =>
+      _$CategoryCopyWithImpl<Category>(this as Category, _$identity);
+
+  @override
+  bool operator ==(Object other) {
+    return identical(this, other) ||
+        (other.runtimeType == runtimeType &&
+            other is Category &&
+            (identical(other.id, id) || other.id == id) &&
+            (identical(other.parentId, parentId) ||
+                other.parentId == parentId) &&
+            (identical(other.treeType, treeType) ||
+                other.treeType == treeType) &&
+            (identical(other.name, name) || other.name == name) &&
+            (identical(other.iconRef, iconRef) || other.iconRef == iconRef) &&
+            (identical(other.isDeleted, isDeleted) ||
+                other.isDeleted == isDeleted) &&
+            (identical(other.deletedAt, deletedAt) ||
+                other.deletedAt == deletedAt) &&
+            (identical(other.isProtected, isProtected) ||
+                other.isProtected == isProtected) &&
+            (identical(other.sortOrder, sortOrder) ||
+                other.sortOrder == sortOrder) &&
+            (identical(other.createdAt, createdAt) ||
+                other.createdAt == createdAt) &&
+            (identical(other.updatedAt, updatedAt) ||
+                other.updatedAt == updatedAt));
+  }
+
+  @override
+  int get hashCode => Object.hash(
+      runtimeType,
+      id,
+      parentId,
+      treeType,
+      name,
+      iconRef,
+      isDeleted,
+      deletedAt,
+      isProtected,
+      sortOrder,
+      createdAt,
+      updatedAt);
+
+  @override
+  String toString() {
+    return 'Category(id: $id, parentId: $parentId, treeType: $treeType, name: $name, iconRef: $iconRef, isDeleted: $isDeleted, deletedAt: $deletedAt, isProtected: $isProtected, sortOrder: $sortOrder, createdAt: $createdAt, updatedAt: $updatedAt)';
+  }
+}
+
+/// @nodoc
+abstract mixin class $CategoryCopyWith<$Res> {
+  factory $CategoryCopyWith(Category value, $Res Function(Category) _then) =
+      _$CategoryCopyWithImpl;
+  @useResult
+  $Res call(
+      {String id,
+      String? parentId,
+      CategoryTreeType treeType,
+      String name,
+      String iconRef,
+      bool isDeleted,
+      int? deletedAt,
+      bool isProtected,
+      int? sortOrder,
+      int createdAt,
+      int updatedAt});
+}
+
+/// @nodoc
+class _$CategoryCopyWithImpl<$Res> implements $CategoryCopyWith<$Res> {
+  _$CategoryCopyWithImpl(this._self, this._then);
+
+  final Category _self;
+  final $Res Function(Category) _then;
+
+  /// Create a copy of Category
+  /// with the given fields replaced by the non-null parameter values.
+  @pragma('vm:prefer-inline')
+  @override
+  $Res call({
+    Object? id = null,
+    Object? parentId = freezed,
+    Object? treeType = null,
+    Object? name = null,
+    Object? iconRef = null,
+    Object? isDeleted = null,
+    Object? deletedAt = freezed,
+    Object? isProtected = null,
+    Object? sortOrder = freezed,
+    Object? createdAt = null,
+    Object? updatedAt = null,
+  }) {
+    return _then(_self.copyWith(
+      id: null == id
+          ? _self.id
+          : id // ignore: cast_nullable_to_non_nullable
+              as String,
+      parentId: freezed == parentId
+          ? _self.parentId
+          : parentId // ignore: cast_nullable_to_non_nullable
+              as String?,
+      treeType: null == treeType
+          ? _self.treeType
+          : treeType // ignore: cast_nullable_to_non_nullable
+              as CategoryTreeType,
+      name: null == name
+          ? _self.name
+          : name // ignore: cast_nullable_to_non_nullable
+              as String,
+      iconRef: null == iconRef
+          ? _self.iconRef
+          : iconRef // ignore: cast_nullable_to_non_nullable
+              as String,
+      isDeleted: null == isDeleted
+          ? _self.isDeleted
+          : isDeleted // ignore: cast_nullable_to_non_nullable
+              as bool,
+      deletedAt: freezed == deletedAt
+          ? _self.deletedAt
+          : deletedAt // ignore: cast_nullable_to_non_nullable
+              as int?,
+      isProtected: null == isProtected
+          ? _self.isProtected
+          : isProtected // ignore: cast_nullable_to_non_nullable
+              as bool,
+      sortOrder: freezed == sortOrder
+          ? _self.sortOrder
+          : sortOrder // ignore: cast_nullable_to_non_nullable
+              as int?,
+      createdAt: null == createdAt
+          ? _self.createdAt
+          : createdAt // ignore: cast_nullable_to_non_nullable
+              as int,
+      updatedAt: null == updatedAt
+          ? _self.updatedAt
+          : updatedAt // ignore: cast_nullable_to_non_nullable
+              as int,
+    ));
+  }
+}
+
+/// Adds pattern-matching-related methods to [Category].
+extension CategoryPatterns on Category {
+  /// A variant of `map` that fallback to returning `orElse`.
+  ///
+  /// It is equivalent to doing:
+  /// ```dart
+  /// switch (sealedClass) {
+  ///   case final Subclass value:
+  ///     return ...;
+  ///   case _:
+  ///     return orElse();
+  /// }
+  /// ```
+
+  @optionalTypeArgs
+  TResult maybeMap<TResult extends Object?>(
+    TResult Function(_Category value)? $default, {
+    required TResult orElse(),
+  }) {
+    final _that = this;
+    switch (_that) {
+      case _Category() when $default != null:
+        return $default(_that);
+      case _:
+        return orElse();
+    }
+  }
+
+  /// A `switch`-like method, using callbacks.
+  ///
+  /// Callbacks receives the raw object, upcasted.
+  /// It is equivalent to doing:
+  /// ```dart
+  /// switch (sealedClass) {
+  ///   case final Subclass value:
+  ///     return ...;
+  ///   case final Subclass2 value:
+  ///     return ...;
+  /// }
+  /// ```
+
+  @optionalTypeArgs
+  TResult map<TResult extends Object?>(
+    TResult Function(_Category value) $default,
+  ) {
+    final _that = this;
+    switch (_that) {
+      case _Category():
+        return $default(_that);
+      case _:
+        throw StateError('Unexpected subclass');
+    }
+  }
+
+  /// A variant of `map` that fallback to returning `null`.
+  ///
+  /// It is equivalent to doing:
+  /// ```dart
+  /// switch (sealedClass) {
+  ///   case final Subclass value:
+  ///     return ...;
+  ///   case _:
+  ///     return null;
+  /// }
+  /// ```
+
+  @optionalTypeArgs
+  TResult? mapOrNull<TResult extends Object?>(
+    TResult? Function(_Category value)? $default,
+  ) {
+    final _that = this;
+    switch (_that) {
+      case _Category() when $default != null:
+        return $default(_that);
+      case _:
+        return null;
+    }
+  }
+
+  /// A variant of `when` that fallback to an `orElse` callback.
+  ///
+  /// It is equivalent to doing:
+  /// ```dart
+  /// switch (sealedClass) {
+  ///   case Subclass(:final field):
+  ///     return ...;
+  ///   case _:
+  ///     return orElse();
+  /// }
+  /// ```
+
+  @optionalTypeArgs
+  TResult maybeWhen<TResult extends Object?>(
+    TResult Function(
+            String id,
+            String? parentId,
+            CategoryTreeType treeType,
+            String name,
+            String iconRef,
+            bool isDeleted,
+            int? deletedAt,
+            bool isProtected,
+            int? sortOrder,
+            int createdAt,
+            int updatedAt)?
+        $default, {
+    required TResult orElse(),
+  }) {
+    final _that = this;
+    switch (_that) {
+      case _Category() when $default != null:
+        return $default(
+            _that.id,
+            _that.parentId,
+            _that.treeType,
+            _that.name,
+            _that.iconRef,
+            _that.isDeleted,
+            _that.deletedAt,
+            _that.isProtected,
+            _that.sortOrder,
+            _that.createdAt,
+            _that.updatedAt);
+      case _:
+        return orElse();
+    }
+  }
+
+  /// A `switch`-like method, using callbacks.
+  ///
+  /// As opposed to `map`, this offers destructuring.
+  /// It is equivalent to doing:
+  /// ```dart
+  /// switch (sealedClass) {
+  ///   case Subclass(:final field):
+  ///     return ...;
+  ///   case Subclass2(:final field2):
+  ///     return ...;
+  /// }
+  /// ```
+
+  @optionalTypeArgs
+  TResult when<TResult extends Object?>(
+    TResult Function(
+            String id,
+            String? parentId,
+            CategoryTreeType treeType,
+            String name,
+            String iconRef,
+            bool isDeleted,
+            int? deletedAt,
+            bool isProtected,
+            int? sortOrder,
+            int createdAt,
+            int updatedAt)
+        $default,
+  ) {
+    final _that = this;
+    switch (_that) {
+      case _Category():
+        return $default(
+            _that.id,
+            _that.parentId,
+            _that.treeType,
+            _that.name,
+            _that.iconRef,
+            _that.isDeleted,
+            _that.deletedAt,
+            _that.isProtected,
+            _that.sortOrder,
+            _that.createdAt,
+            _that.updatedAt);
+      case _:
+        throw StateError('Unexpected subclass');
+    }
+  }
+
+  /// A variant of `when` that fallback to returning `null`
+  ///
+  /// It is equivalent to doing:
+  /// ```dart
+  /// switch (sealedClass) {
+  ///   case Subclass(:final field):
+  ///     return ...;
+  ///   case _:
+  ///     return null;
+  /// }
+  /// ```
+
+  @optionalTypeArgs
+  TResult? whenOrNull<TResult extends Object?>(
+    TResult? Function(
+            String id,
+            String? parentId,
+            CategoryTreeType treeType,
+            String name,
+            String iconRef,
+            bool isDeleted,
+            int? deletedAt,
+            bool isProtected,
+            int? sortOrder,
+            int createdAt,
+            int updatedAt)?
+        $default,
+  ) {
+    final _that = this;
+    switch (_that) {
+      case _Category() when $default != null:
+        return $default(
+            _that.id,
+            _that.parentId,
+            _that.treeType,
+            _that.name,
+            _that.iconRef,
+            _that.isDeleted,
+            _that.deletedAt,
+            _that.isProtected,
+            _that.sortOrder,
+            _that.createdAt,
+            _that.updatedAt);
+      case _:
+        return null;
+    }
+  }
+}
+
+/// @nodoc
+
+class _Category implements Category {
+  const _Category(
+      {required this.id,
+      this.parentId,
+      required this.treeType,
+      required this.name,
+      required this.iconRef,
+      this.isDeleted = false,
+      this.deletedAt,
+      this.isProtected = false,
+      this.sortOrder,
+      required this.createdAt,
+      required this.updatedAt});
+
+  /// UUID v4 stable identifier.
+  @override
+  final String id;
+
+  /// Parent category UUID; null for root categories.
+  @override
+  final String? parentId;
+
+  /// Income or expense tree.
+  @override
+  final CategoryTreeType treeType;
+
+  /// Display name; unique within tree/parent (case-insensitive, incl. soft-deleted).
+  @override
+  final String name;
+
+  /// Material Symbols icon identifier.
+  @override
+  final String iconRef;
+
+  /// Soft-delete flag.
+  @override
+  @JsonKey()
+  final bool isDeleted;
+
+  /// Soft-delete epoch (Unix seconds); set when [isDeleted] becomes true.
+  @override
+  final int? deletedAt;
+
+  /// True for BAI/BAE and "Balance Adjustment" parent; blocks deletion.
+  @override
+  @JsonKey()
+  final bool isProtected;
+
+  /// Manual sort order; null = alphabetical (v1 default).
+  @override
+  final int? sortOrder;
+
+  /// Creation epoch (Unix seconds).
+  @override
+  final int createdAt;
+
+  /// Last-modified epoch (Unix seconds).
+  @override
+  final int updatedAt;
+
+  /// Create a copy of Category
+  /// with the given fields replaced by the non-null parameter values.
+  @override
+  @JsonKey(includeFromJson: false, includeToJson: false)
+  @pragma('vm:prefer-inline')
+  _$CategoryCopyWith<_Category> get copyWith =>
+      __$CategoryCopyWithImpl<_Category>(this, _$identity);
+
+  @override
+  bool operator ==(Object other) {
+    return identical(this, other) ||
+        (other.runtimeType == runtimeType &&
+            other is _Category &&
+            (identical(other.id, id) || other.id == id) &&
+            (identical(other.parentId, parentId) ||
+                other.parentId == parentId) &&
+            (identical(other.treeType, treeType) ||
+                other.treeType == treeType) &&
+            (identical(other.name, name) || other.name == name) &&
+            (identical(other.iconRef, iconRef) || other.iconRef == iconRef) &&
+            (identical(other.isDeleted, isDeleted) ||
+                other.isDeleted == isDeleted) &&
+            (identical(other.deletedAt, deletedAt) ||
+                other.deletedAt == deletedAt) &&
+            (identical(other.isProtected, isProtected) ||
+                other.isProtected == isProtected) &&
+            (identical(other.sortOrder, sortOrder) ||
+                other.sortOrder == sortOrder) &&
+            (identical(other.createdAt, createdAt) ||
+                other.createdAt == createdAt) &&
+            (identical(other.updatedAt, updatedAt) ||
+                other.updatedAt == updatedAt));
+  }
+
+  @override
+  int get hashCode => Object.hash(
+      runtimeType,
+      id,
+      parentId,
+      treeType,
+      name,
+      iconRef,
+      isDeleted,
+      deletedAt,
+      isProtected,
+      sortOrder,
+      createdAt,
+      updatedAt);
+
+  @override
+  String toString() {
+    return 'Category(id: $id, parentId: $parentId, treeType: $treeType, name: $name, iconRef: $iconRef, isDeleted: $isDeleted, deletedAt: $deletedAt, isProtected: $isProtected, sortOrder: $sortOrder, createdAt: $createdAt, updatedAt: $updatedAt)';
+  }
+}
+
+/// @nodoc
+abstract mixin class _$CategoryCopyWith<$Res>
+    implements $CategoryCopyWith<$Res> {
+  factory _$CategoryCopyWith(_Category value, $Res Function(_Category) _then) =
+      __$CategoryCopyWithImpl;
+  @override
+  @useResult
+  $Res call(
+      {String id,
+      String? parentId,
+      CategoryTreeType treeType,
+      String name,
+      String iconRef,
+      bool isDeleted,
+      int? deletedAt,
+      bool isProtected,
+      int? sortOrder,
+      int createdAt,
+      int updatedAt});
+}
+
+/// @nodoc
+class __$CategoryCopyWithImpl<$Res> implements _$CategoryCopyWith<$Res> {
+  __$CategoryCopyWithImpl(this._self, this._then);
+
+  final _Category _self;
+  final $Res Function(_Category) _then;
+
+  /// Create a copy of Category
+  /// with the given fields replaced by the non-null parameter values.
+  @override
+  @pragma('vm:prefer-inline')
+  $Res call({
+    Object? id = null,
+    Object? parentId = freezed,
+    Object? treeType = null,
+    Object? name = null,
+    Object? iconRef = null,
+    Object? isDeleted = null,
+    Object? deletedAt = freezed,
+    Object? isProtected = null,
+    Object? sortOrder = freezed,
+    Object? createdAt = null,
+    Object? updatedAt = null,
+  }) {
+    return _then(_Category(
+      id: null == id
+          ? _self.id
+          : id // ignore: cast_nullable_to_non_nullable
+              as String,
+      parentId: freezed == parentId
+          ? _self.parentId
+          : parentId // ignore: cast_nullable_to_non_nullable
+              as String?,
+      treeType: null == treeType
+          ? _self.treeType
+          : treeType // ignore: cast_nullable_to_non_nullable
+              as CategoryTreeType,
+      name: null == name
+          ? _self.name
+          : name // ignore: cast_nullable_to_non_nullable
+              as String,
+      iconRef: null == iconRef
+          ? _self.iconRef
+          : iconRef // ignore: cast_nullable_to_non_nullable
+              as String,
+      isDeleted: null == isDeleted
+          ? _self.isDeleted
+          : isDeleted // ignore: cast_nullable_to_non_nullable
+              as bool,
+      deletedAt: freezed == deletedAt
+          ? _self.deletedAt
+          : deletedAt // ignore: cast_nullable_to_non_nullable
+              as int?,
+      isProtected: null == isProtected
+          ? _self.isProtected
+          : isProtected // ignore: cast_nullable_to_non_nullable
+              as bool,
+      sortOrder: freezed == sortOrder
+          ? _self.sortOrder
+          : sortOrder // ignore: cast_nullable_to_non_nullable
+              as int?,
+      createdAt: null == createdAt
+          ? _self.createdAt
+          : createdAt // ignore: cast_nullable_to_non_nullable
+              as int,
+      updatedAt: null == updatedAt
+          ? _self.updatedAt
+          : updatedAt // ignore: cast_nullable_to_non_nullable
+              as int,
+    ));
+  }
+}
+
+// dart format on

--- a/lib/domain/entities/currency.dart
+++ b/lib/domain/entities/currency.dart
@@ -1,0 +1,34 @@
+// lib/domain/entities/currency.dart
+//
+// Currency domain entity.
+//
+// ISO 4217 currency reference. Read-only at runtime; populated from the
+// bundled currencies.json asset at first launch (~180 currencies).
+//
+// Amount storage rule: all monetary amounts are stored as INTEGER in minor
+// units (e.g. JPY minor_units=0, USD minor_units=2, BHD minor_units=3).
+
+import 'package:freezed_annotation/freezed_annotation.dart';
+
+part 'currency.freezed.dart';
+
+/// Immutable domain entity for an ISO 4217 currency.
+@freezed
+abstract class Currency with _$Currency {
+  const factory Currency({
+    /// ISO 4217 three-letter code (e.g. 'USD', 'INR', 'JPY').
+    required String code,
+
+    /// Full English name (e.g. 'US Dollar').
+    required String name,
+
+    /// Display symbol (e.g. '$', '₹').
+    required String symbol,
+
+    /// Number of decimal places: 0 for JPY, 2 for USD, 3 for BHD.
+    @Default(2) int minorUnits,
+
+    /// False for retired ISO currencies.
+    @Default(true) bool isActive,
+  }) = _Currency;
+}

--- a/lib/domain/entities/currency.freezed.dart
+++ b/lib/domain/entities/currency.freezed.dart
@@ -1,0 +1,399 @@
+// GENERATED CODE - DO NOT MODIFY BY HAND
+// coverage:ignore-file
+// ignore_for_file: type=lint
+// ignore_for_file: unused_element, deprecated_member_use, deprecated_member_use_from_same_package, use_function_type_syntax_for_parameters, unnecessary_const, avoid_init_to_null, invalid_override_different_default_values_named, prefer_expression_function_bodies, annotate_overrides, invalid_annotation_target, unnecessary_question_mark
+
+part of 'currency.dart';
+
+// **************************************************************************
+// FreezedGenerator
+// **************************************************************************
+
+// dart format off
+T _$identity<T>(T value) => value;
+
+/// @nodoc
+mixin _$Currency {
+  /// ISO 4217 three-letter code (e.g. 'USD', 'INR', 'JPY').
+  String get code;
+
+  /// Full English name (e.g. 'US Dollar').
+  String get name;
+
+  /// Display symbol (e.g. '$', '₹').
+  String get symbol;
+
+  /// Number of decimal places: 0 for JPY, 2 for USD, 3 for BHD.
+  int get minorUnits;
+
+  /// False for retired ISO currencies.
+  bool get isActive;
+
+  /// Create a copy of Currency
+  /// with the given fields replaced by the non-null parameter values.
+  @JsonKey(includeFromJson: false, includeToJson: false)
+  @pragma('vm:prefer-inline')
+  $CurrencyCopyWith<Currency> get copyWith =>
+      _$CurrencyCopyWithImpl<Currency>(this as Currency, _$identity);
+
+  @override
+  bool operator ==(Object other) {
+    return identical(this, other) ||
+        (other.runtimeType == runtimeType &&
+            other is Currency &&
+            (identical(other.code, code) || other.code == code) &&
+            (identical(other.name, name) || other.name == name) &&
+            (identical(other.symbol, symbol) || other.symbol == symbol) &&
+            (identical(other.minorUnits, minorUnits) ||
+                other.minorUnits == minorUnits) &&
+            (identical(other.isActive, isActive) ||
+                other.isActive == isActive));
+  }
+
+  @override
+  int get hashCode =>
+      Object.hash(runtimeType, code, name, symbol, minorUnits, isActive);
+
+  @override
+  String toString() {
+    return 'Currency(code: $code, name: $name, symbol: $symbol, minorUnits: $minorUnits, isActive: $isActive)';
+  }
+}
+
+/// @nodoc
+abstract mixin class $CurrencyCopyWith<$Res> {
+  factory $CurrencyCopyWith(Currency value, $Res Function(Currency) _then) =
+      _$CurrencyCopyWithImpl;
+  @useResult
+  $Res call(
+      {String code, String name, String symbol, int minorUnits, bool isActive});
+}
+
+/// @nodoc
+class _$CurrencyCopyWithImpl<$Res> implements $CurrencyCopyWith<$Res> {
+  _$CurrencyCopyWithImpl(this._self, this._then);
+
+  final Currency _self;
+  final $Res Function(Currency) _then;
+
+  /// Create a copy of Currency
+  /// with the given fields replaced by the non-null parameter values.
+  @pragma('vm:prefer-inline')
+  @override
+  $Res call({
+    Object? code = null,
+    Object? name = null,
+    Object? symbol = null,
+    Object? minorUnits = null,
+    Object? isActive = null,
+  }) {
+    return _then(_self.copyWith(
+      code: null == code
+          ? _self.code
+          : code // ignore: cast_nullable_to_non_nullable
+              as String,
+      name: null == name
+          ? _self.name
+          : name // ignore: cast_nullable_to_non_nullable
+              as String,
+      symbol: null == symbol
+          ? _self.symbol
+          : symbol // ignore: cast_nullable_to_non_nullable
+              as String,
+      minorUnits: null == minorUnits
+          ? _self.minorUnits
+          : minorUnits // ignore: cast_nullable_to_non_nullable
+              as int,
+      isActive: null == isActive
+          ? _self.isActive
+          : isActive // ignore: cast_nullable_to_non_nullable
+              as bool,
+    ));
+  }
+}
+
+/// Adds pattern-matching-related methods to [Currency].
+extension CurrencyPatterns on Currency {
+  /// A variant of `map` that fallback to returning `orElse`.
+  ///
+  /// It is equivalent to doing:
+  /// ```dart
+  /// switch (sealedClass) {
+  ///   case final Subclass value:
+  ///     return ...;
+  ///   case _:
+  ///     return orElse();
+  /// }
+  /// ```
+
+  @optionalTypeArgs
+  TResult maybeMap<TResult extends Object?>(
+    TResult Function(_Currency value)? $default, {
+    required TResult orElse(),
+  }) {
+    final _that = this;
+    switch (_that) {
+      case _Currency() when $default != null:
+        return $default(_that);
+      case _:
+        return orElse();
+    }
+  }
+
+  /// A `switch`-like method, using callbacks.
+  ///
+  /// Callbacks receives the raw object, upcasted.
+  /// It is equivalent to doing:
+  /// ```dart
+  /// switch (sealedClass) {
+  ///   case final Subclass value:
+  ///     return ...;
+  ///   case final Subclass2 value:
+  ///     return ...;
+  /// }
+  /// ```
+
+  @optionalTypeArgs
+  TResult map<TResult extends Object?>(
+    TResult Function(_Currency value) $default,
+  ) {
+    final _that = this;
+    switch (_that) {
+      case _Currency():
+        return $default(_that);
+      case _:
+        throw StateError('Unexpected subclass');
+    }
+  }
+
+  /// A variant of `map` that fallback to returning `null`.
+  ///
+  /// It is equivalent to doing:
+  /// ```dart
+  /// switch (sealedClass) {
+  ///   case final Subclass value:
+  ///     return ...;
+  ///   case _:
+  ///     return null;
+  /// }
+  /// ```
+
+  @optionalTypeArgs
+  TResult? mapOrNull<TResult extends Object?>(
+    TResult? Function(_Currency value)? $default,
+  ) {
+    final _that = this;
+    switch (_that) {
+      case _Currency() when $default != null:
+        return $default(_that);
+      case _:
+        return null;
+    }
+  }
+
+  /// A variant of `when` that fallback to an `orElse` callback.
+  ///
+  /// It is equivalent to doing:
+  /// ```dart
+  /// switch (sealedClass) {
+  ///   case Subclass(:final field):
+  ///     return ...;
+  ///   case _:
+  ///     return orElse();
+  /// }
+  /// ```
+
+  @optionalTypeArgs
+  TResult maybeWhen<TResult extends Object?>(
+    TResult Function(String code, String name, String symbol, int minorUnits,
+            bool isActive)?
+        $default, {
+    required TResult orElse(),
+  }) {
+    final _that = this;
+    switch (_that) {
+      case _Currency() when $default != null:
+        return $default(_that.code, _that.name, _that.symbol, _that.minorUnits,
+            _that.isActive);
+      case _:
+        return orElse();
+    }
+  }
+
+  /// A `switch`-like method, using callbacks.
+  ///
+  /// As opposed to `map`, this offers destructuring.
+  /// It is equivalent to doing:
+  /// ```dart
+  /// switch (sealedClass) {
+  ///   case Subclass(:final field):
+  ///     return ...;
+  ///   case Subclass2(:final field2):
+  ///     return ...;
+  /// }
+  /// ```
+
+  @optionalTypeArgs
+  TResult when<TResult extends Object?>(
+    TResult Function(String code, String name, String symbol, int minorUnits,
+            bool isActive)
+        $default,
+  ) {
+    final _that = this;
+    switch (_that) {
+      case _Currency():
+        return $default(_that.code, _that.name, _that.symbol, _that.minorUnits,
+            _that.isActive);
+      case _:
+        throw StateError('Unexpected subclass');
+    }
+  }
+
+  /// A variant of `when` that fallback to returning `null`
+  ///
+  /// It is equivalent to doing:
+  /// ```dart
+  /// switch (sealedClass) {
+  ///   case Subclass(:final field):
+  ///     return ...;
+  ///   case _:
+  ///     return null;
+  /// }
+  /// ```
+
+  @optionalTypeArgs
+  TResult? whenOrNull<TResult extends Object?>(
+    TResult? Function(String code, String name, String symbol, int minorUnits,
+            bool isActive)?
+        $default,
+  ) {
+    final _that = this;
+    switch (_that) {
+      case _Currency() when $default != null:
+        return $default(_that.code, _that.name, _that.symbol, _that.minorUnits,
+            _that.isActive);
+      case _:
+        return null;
+    }
+  }
+}
+
+/// @nodoc
+
+class _Currency implements Currency {
+  const _Currency(
+      {required this.code,
+      required this.name,
+      required this.symbol,
+      this.minorUnits = 2,
+      this.isActive = true});
+
+  /// ISO 4217 three-letter code (e.g. 'USD', 'INR', 'JPY').
+  @override
+  final String code;
+
+  /// Full English name (e.g. 'US Dollar').
+  @override
+  final String name;
+
+  /// Display symbol (e.g. '$', '₹').
+  @override
+  final String symbol;
+
+  /// Number of decimal places: 0 for JPY, 2 for USD, 3 for BHD.
+  @override
+  @JsonKey()
+  final int minorUnits;
+
+  /// False for retired ISO currencies.
+  @override
+  @JsonKey()
+  final bool isActive;
+
+  /// Create a copy of Currency
+  /// with the given fields replaced by the non-null parameter values.
+  @override
+  @JsonKey(includeFromJson: false, includeToJson: false)
+  @pragma('vm:prefer-inline')
+  _$CurrencyCopyWith<_Currency> get copyWith =>
+      __$CurrencyCopyWithImpl<_Currency>(this, _$identity);
+
+  @override
+  bool operator ==(Object other) {
+    return identical(this, other) ||
+        (other.runtimeType == runtimeType &&
+            other is _Currency &&
+            (identical(other.code, code) || other.code == code) &&
+            (identical(other.name, name) || other.name == name) &&
+            (identical(other.symbol, symbol) || other.symbol == symbol) &&
+            (identical(other.minorUnits, minorUnits) ||
+                other.minorUnits == minorUnits) &&
+            (identical(other.isActive, isActive) ||
+                other.isActive == isActive));
+  }
+
+  @override
+  int get hashCode =>
+      Object.hash(runtimeType, code, name, symbol, minorUnits, isActive);
+
+  @override
+  String toString() {
+    return 'Currency(code: $code, name: $name, symbol: $symbol, minorUnits: $minorUnits, isActive: $isActive)';
+  }
+}
+
+/// @nodoc
+abstract mixin class _$CurrencyCopyWith<$Res>
+    implements $CurrencyCopyWith<$Res> {
+  factory _$CurrencyCopyWith(_Currency value, $Res Function(_Currency) _then) =
+      __$CurrencyCopyWithImpl;
+  @override
+  @useResult
+  $Res call(
+      {String code, String name, String symbol, int minorUnits, bool isActive});
+}
+
+/// @nodoc
+class __$CurrencyCopyWithImpl<$Res> implements _$CurrencyCopyWith<$Res> {
+  __$CurrencyCopyWithImpl(this._self, this._then);
+
+  final _Currency _self;
+  final $Res Function(_Currency) _then;
+
+  /// Create a copy of Currency
+  /// with the given fields replaced by the non-null parameter values.
+  @override
+  @pragma('vm:prefer-inline')
+  $Res call({
+    Object? code = null,
+    Object? name = null,
+    Object? symbol = null,
+    Object? minorUnits = null,
+    Object? isActive = null,
+  }) {
+    return _then(_Currency(
+      code: null == code
+          ? _self.code
+          : code // ignore: cast_nullable_to_non_nullable
+              as String,
+      name: null == name
+          ? _self.name
+          : name // ignore: cast_nullable_to_non_nullable
+              as String,
+      symbol: null == symbol
+          ? _self.symbol
+          : symbol // ignore: cast_nullable_to_non_nullable
+              as String,
+      minorUnits: null == minorUnits
+          ? _self.minorUnits
+          : minorUnits // ignore: cast_nullable_to_non_nullable
+              as int,
+      isActive: null == isActive
+          ? _self.isActive
+          : isActive // ignore: cast_nullable_to_non_nullable
+              as bool,
+    ));
+  }
+}
+
+// dart format on

--- a/lib/domain/entities/draft.dart
+++ b/lib/domain/entities/draft.dart
@@ -1,0 +1,28 @@
+// lib/domain/entities/draft.dart
+//
+// Draft domain entity.
+//
+// Auto-saved transaction entry form state. Max 5 rows enforced at app layer
+// (FIFO eviction). Not part of the ledger; purely a UX convenience.
+
+import 'package:freezed_annotation/freezed_annotation.dart';
+
+part 'draft.freezed.dart';
+
+/// Immutable domain entity for an auto-saved form draft.
+@freezed
+abstract class Draft with _$Draft {
+  const factory Draft({
+    /// UUID v4 stable identifier.
+    required String id,
+
+    /// Serialized form state (JSON string).
+    required String payloadJson,
+
+    /// Creation epoch used for FIFO eviction (Unix seconds).
+    required int createdAt,
+
+    /// Last auto-save epoch (Unix seconds).
+    required int updatedAt,
+  }) = _Draft;
+}

--- a/lib/domain/entities/draft.freezed.dart
+++ b/lib/domain/entities/draft.freezed.dart
@@ -1,0 +1,376 @@
+// GENERATED CODE - DO NOT MODIFY BY HAND
+// coverage:ignore-file
+// ignore_for_file: type=lint
+// ignore_for_file: unused_element, deprecated_member_use, deprecated_member_use_from_same_package, use_function_type_syntax_for_parameters, unnecessary_const, avoid_init_to_null, invalid_override_different_default_values_named, prefer_expression_function_bodies, annotate_overrides, invalid_annotation_target, unnecessary_question_mark
+
+part of 'draft.dart';
+
+// **************************************************************************
+// FreezedGenerator
+// **************************************************************************
+
+// dart format off
+T _$identity<T>(T value) => value;
+
+/// @nodoc
+mixin _$Draft {
+  /// UUID v4 stable identifier.
+  String get id;
+
+  /// Serialized form state (JSON string).
+  String get payloadJson;
+
+  /// Creation epoch used for FIFO eviction (Unix seconds).
+  int get createdAt;
+
+  /// Last auto-save epoch (Unix seconds).
+  int get updatedAt;
+
+  /// Create a copy of Draft
+  /// with the given fields replaced by the non-null parameter values.
+  @JsonKey(includeFromJson: false, includeToJson: false)
+  @pragma('vm:prefer-inline')
+  $DraftCopyWith<Draft> get copyWith =>
+      _$DraftCopyWithImpl<Draft>(this as Draft, _$identity);
+
+  @override
+  bool operator ==(Object other) {
+    return identical(this, other) ||
+        (other.runtimeType == runtimeType &&
+            other is Draft &&
+            (identical(other.id, id) || other.id == id) &&
+            (identical(other.payloadJson, payloadJson) ||
+                other.payloadJson == payloadJson) &&
+            (identical(other.createdAt, createdAt) ||
+                other.createdAt == createdAt) &&
+            (identical(other.updatedAt, updatedAt) ||
+                other.updatedAt == updatedAt));
+  }
+
+  @override
+  int get hashCode =>
+      Object.hash(runtimeType, id, payloadJson, createdAt, updatedAt);
+
+  @override
+  String toString() {
+    return 'Draft(id: $id, payloadJson: $payloadJson, createdAt: $createdAt, updatedAt: $updatedAt)';
+  }
+}
+
+/// @nodoc
+abstract mixin class $DraftCopyWith<$Res> {
+  factory $DraftCopyWith(Draft value, $Res Function(Draft) _then) =
+      _$DraftCopyWithImpl;
+  @useResult
+  $Res call({String id, String payloadJson, int createdAt, int updatedAt});
+}
+
+/// @nodoc
+class _$DraftCopyWithImpl<$Res> implements $DraftCopyWith<$Res> {
+  _$DraftCopyWithImpl(this._self, this._then);
+
+  final Draft _self;
+  final $Res Function(Draft) _then;
+
+  /// Create a copy of Draft
+  /// with the given fields replaced by the non-null parameter values.
+  @pragma('vm:prefer-inline')
+  @override
+  $Res call({
+    Object? id = null,
+    Object? payloadJson = null,
+    Object? createdAt = null,
+    Object? updatedAt = null,
+  }) {
+    return _then(_self.copyWith(
+      id: null == id
+          ? _self.id
+          : id // ignore: cast_nullable_to_non_nullable
+              as String,
+      payloadJson: null == payloadJson
+          ? _self.payloadJson
+          : payloadJson // ignore: cast_nullable_to_non_nullable
+              as String,
+      createdAt: null == createdAt
+          ? _self.createdAt
+          : createdAt // ignore: cast_nullable_to_non_nullable
+              as int,
+      updatedAt: null == updatedAt
+          ? _self.updatedAt
+          : updatedAt // ignore: cast_nullable_to_non_nullable
+              as int,
+    ));
+  }
+}
+
+/// Adds pattern-matching-related methods to [Draft].
+extension DraftPatterns on Draft {
+  /// A variant of `map` that fallback to returning `orElse`.
+  ///
+  /// It is equivalent to doing:
+  /// ```dart
+  /// switch (sealedClass) {
+  ///   case final Subclass value:
+  ///     return ...;
+  ///   case _:
+  ///     return orElse();
+  /// }
+  /// ```
+
+  @optionalTypeArgs
+  TResult maybeMap<TResult extends Object?>(
+    TResult Function(_Draft value)? $default, {
+    required TResult orElse(),
+  }) {
+    final _that = this;
+    switch (_that) {
+      case _Draft() when $default != null:
+        return $default(_that);
+      case _:
+        return orElse();
+    }
+  }
+
+  /// A `switch`-like method, using callbacks.
+  ///
+  /// Callbacks receives the raw object, upcasted.
+  /// It is equivalent to doing:
+  /// ```dart
+  /// switch (sealedClass) {
+  ///   case final Subclass value:
+  ///     return ...;
+  ///   case final Subclass2 value:
+  ///     return ...;
+  /// }
+  /// ```
+
+  @optionalTypeArgs
+  TResult map<TResult extends Object?>(
+    TResult Function(_Draft value) $default,
+  ) {
+    final _that = this;
+    switch (_that) {
+      case _Draft():
+        return $default(_that);
+      case _:
+        throw StateError('Unexpected subclass');
+    }
+  }
+
+  /// A variant of `map` that fallback to returning `null`.
+  ///
+  /// It is equivalent to doing:
+  /// ```dart
+  /// switch (sealedClass) {
+  ///   case final Subclass value:
+  ///     return ...;
+  ///   case _:
+  ///     return null;
+  /// }
+  /// ```
+
+  @optionalTypeArgs
+  TResult? mapOrNull<TResult extends Object?>(
+    TResult? Function(_Draft value)? $default,
+  ) {
+    final _that = this;
+    switch (_that) {
+      case _Draft() when $default != null:
+        return $default(_that);
+      case _:
+        return null;
+    }
+  }
+
+  /// A variant of `when` that fallback to an `orElse` callback.
+  ///
+  /// It is equivalent to doing:
+  /// ```dart
+  /// switch (sealedClass) {
+  ///   case Subclass(:final field):
+  ///     return ...;
+  ///   case _:
+  ///     return orElse();
+  /// }
+  /// ```
+
+  @optionalTypeArgs
+  TResult maybeWhen<TResult extends Object?>(
+    TResult Function(
+            String id, String payloadJson, int createdAt, int updatedAt)?
+        $default, {
+    required TResult orElse(),
+  }) {
+    final _that = this;
+    switch (_that) {
+      case _Draft() when $default != null:
+        return $default(
+            _that.id, _that.payloadJson, _that.createdAt, _that.updatedAt);
+      case _:
+        return orElse();
+    }
+  }
+
+  /// A `switch`-like method, using callbacks.
+  ///
+  /// As opposed to `map`, this offers destructuring.
+  /// It is equivalent to doing:
+  /// ```dart
+  /// switch (sealedClass) {
+  ///   case Subclass(:final field):
+  ///     return ...;
+  ///   case Subclass2(:final field2):
+  ///     return ...;
+  /// }
+  /// ```
+
+  @optionalTypeArgs
+  TResult when<TResult extends Object?>(
+    TResult Function(
+            String id, String payloadJson, int createdAt, int updatedAt)
+        $default,
+  ) {
+    final _that = this;
+    switch (_that) {
+      case _Draft():
+        return $default(
+            _that.id, _that.payloadJson, _that.createdAt, _that.updatedAt);
+      case _:
+        throw StateError('Unexpected subclass');
+    }
+  }
+
+  /// A variant of `when` that fallback to returning `null`
+  ///
+  /// It is equivalent to doing:
+  /// ```dart
+  /// switch (sealedClass) {
+  ///   case Subclass(:final field):
+  ///     return ...;
+  ///   case _:
+  ///     return null;
+  /// }
+  /// ```
+
+  @optionalTypeArgs
+  TResult? whenOrNull<TResult extends Object?>(
+    TResult? Function(
+            String id, String payloadJson, int createdAt, int updatedAt)?
+        $default,
+  ) {
+    final _that = this;
+    switch (_that) {
+      case _Draft() when $default != null:
+        return $default(
+            _that.id, _that.payloadJson, _that.createdAt, _that.updatedAt);
+      case _:
+        return null;
+    }
+  }
+}
+
+/// @nodoc
+
+class _Draft implements Draft {
+  const _Draft(
+      {required this.id,
+      required this.payloadJson,
+      required this.createdAt,
+      required this.updatedAt});
+
+  /// UUID v4 stable identifier.
+  @override
+  final String id;
+
+  /// Serialized form state (JSON string).
+  @override
+  final String payloadJson;
+
+  /// Creation epoch used for FIFO eviction (Unix seconds).
+  @override
+  final int createdAt;
+
+  /// Last auto-save epoch (Unix seconds).
+  @override
+  final int updatedAt;
+
+  /// Create a copy of Draft
+  /// with the given fields replaced by the non-null parameter values.
+  @override
+  @JsonKey(includeFromJson: false, includeToJson: false)
+  @pragma('vm:prefer-inline')
+  _$DraftCopyWith<_Draft> get copyWith =>
+      __$DraftCopyWithImpl<_Draft>(this, _$identity);
+
+  @override
+  bool operator ==(Object other) {
+    return identical(this, other) ||
+        (other.runtimeType == runtimeType &&
+            other is _Draft &&
+            (identical(other.id, id) || other.id == id) &&
+            (identical(other.payloadJson, payloadJson) ||
+                other.payloadJson == payloadJson) &&
+            (identical(other.createdAt, createdAt) ||
+                other.createdAt == createdAt) &&
+            (identical(other.updatedAt, updatedAt) ||
+                other.updatedAt == updatedAt));
+  }
+
+  @override
+  int get hashCode =>
+      Object.hash(runtimeType, id, payloadJson, createdAt, updatedAt);
+
+  @override
+  String toString() {
+    return 'Draft(id: $id, payloadJson: $payloadJson, createdAt: $createdAt, updatedAt: $updatedAt)';
+  }
+}
+
+/// @nodoc
+abstract mixin class _$DraftCopyWith<$Res> implements $DraftCopyWith<$Res> {
+  factory _$DraftCopyWith(_Draft value, $Res Function(_Draft) _then) =
+      __$DraftCopyWithImpl;
+  @override
+  @useResult
+  $Res call({String id, String payloadJson, int createdAt, int updatedAt});
+}
+
+/// @nodoc
+class __$DraftCopyWithImpl<$Res> implements _$DraftCopyWith<$Res> {
+  __$DraftCopyWithImpl(this._self, this._then);
+
+  final _Draft _self;
+  final $Res Function(_Draft) _then;
+
+  /// Create a copy of Draft
+  /// with the given fields replaced by the non-null parameter values.
+  @override
+  @pragma('vm:prefer-inline')
+  $Res call({
+    Object? id = null,
+    Object? payloadJson = null,
+    Object? createdAt = null,
+    Object? updatedAt = null,
+  }) {
+    return _then(_Draft(
+      id: null == id
+          ? _self.id
+          : id // ignore: cast_nullable_to_non_nullable
+              as String,
+      payloadJson: null == payloadJson
+          ? _self.payloadJson
+          : payloadJson // ignore: cast_nullable_to_non_nullable
+              as String,
+      createdAt: null == createdAt
+          ? _self.createdAt
+          : createdAt // ignore: cast_nullable_to_non_nullable
+              as int,
+      updatedAt: null == updatedAt
+          ? _self.updatedAt
+          : updatedAt // ignore: cast_nullable_to_non_nullable
+              as int,
+    ));
+  }
+}
+
+// dart format on

--- a/lib/domain/entities/entry.dart
+++ b/lib/domain/entities/entry.dart
@@ -1,0 +1,53 @@
+// lib/domain/entities/entry.dart
+//
+// Entry domain entity — a single DEB ledger line.
+//
+// Each Transaction has ≥ 2 entries satisfying Σ debit = Σ credit.
+// Exactly one of accountId or categoryId must be non-null per row;
+// this exclusivity is enforced at the domain layer (Transaction.validate()).
+//
+// Balance formula for accounts:
+//   balance = Σ(amountMinor WHERE side='debit') − Σ(amountMinor WHERE side='credit')
+
+import 'package:freezed_annotation/freezed_annotation.dart';
+
+part 'entry.freezed.dart';
+
+/// DEB side of a ledger entry.
+enum EntrySide {
+  debit,
+  credit,
+}
+
+/// Immutable domain entity for a single DEB ledger line.
+@freezed
+abstract class Entry with _$Entry {
+  const factory Entry({
+    /// UUID v4 stable identifier.
+    required String id,
+
+    /// Parent transaction UUID.
+    required String transactionId,
+
+    /// Account leg — mutually exclusive with [categoryId].
+    String? accountId,
+
+    /// Category leg — mutually exclusive with [accountId].
+    String? categoryId,
+
+    /// DEB side of this entry.
+    required EntrySide side,
+
+    /// Amount in minor units of [currencyCode].
+    required int amountMinor,
+
+    /// ISO 4217 currency code of this entry.
+    required String currencyCode,
+
+    /// Rate to home currency × 1,000,000; null if same as home currency.
+    int? exchangeRateMicro,
+
+    /// System write epoch (TC-025).
+    required int createdAt,
+  }) = _Entry;
+}

--- a/lib/domain/entities/entry.freezed.dart
+++ b/lib/domain/entities/entry.freezed.dart
@@ -1,0 +1,568 @@
+// GENERATED CODE - DO NOT MODIFY BY HAND
+// coverage:ignore-file
+// ignore_for_file: type=lint
+// ignore_for_file: unused_element, deprecated_member_use, deprecated_member_use_from_same_package, use_function_type_syntax_for_parameters, unnecessary_const, avoid_init_to_null, invalid_override_different_default_values_named, prefer_expression_function_bodies, annotate_overrides, invalid_annotation_target, unnecessary_question_mark
+
+part of 'entry.dart';
+
+// **************************************************************************
+// FreezedGenerator
+// **************************************************************************
+
+// dart format off
+T _$identity<T>(T value) => value;
+
+/// @nodoc
+mixin _$Entry {
+  /// UUID v4 stable identifier.
+  String get id;
+
+  /// Parent transaction UUID.
+  String get transactionId;
+
+  /// Account leg — mutually exclusive with [categoryId].
+  String? get accountId;
+
+  /// Category leg — mutually exclusive with [accountId].
+  String? get categoryId;
+
+  /// DEB side of this entry.
+  EntrySide get side;
+
+  /// Amount in minor units of [currencyCode].
+  int get amountMinor;
+
+  /// ISO 4217 currency code of this entry.
+  String get currencyCode;
+
+  /// Rate to home currency × 1,000,000; null if same as home currency.
+  int? get exchangeRateMicro;
+
+  /// System write epoch (TC-025).
+  int get createdAt;
+
+  /// Create a copy of Entry
+  /// with the given fields replaced by the non-null parameter values.
+  @JsonKey(includeFromJson: false, includeToJson: false)
+  @pragma('vm:prefer-inline')
+  $EntryCopyWith<Entry> get copyWith =>
+      _$EntryCopyWithImpl<Entry>(this as Entry, _$identity);
+
+  @override
+  bool operator ==(Object other) {
+    return identical(this, other) ||
+        (other.runtimeType == runtimeType &&
+            other is Entry &&
+            (identical(other.id, id) || other.id == id) &&
+            (identical(other.transactionId, transactionId) ||
+                other.transactionId == transactionId) &&
+            (identical(other.accountId, accountId) ||
+                other.accountId == accountId) &&
+            (identical(other.categoryId, categoryId) ||
+                other.categoryId == categoryId) &&
+            (identical(other.side, side) || other.side == side) &&
+            (identical(other.amountMinor, amountMinor) ||
+                other.amountMinor == amountMinor) &&
+            (identical(other.currencyCode, currencyCode) ||
+                other.currencyCode == currencyCode) &&
+            (identical(other.exchangeRateMicro, exchangeRateMicro) ||
+                other.exchangeRateMicro == exchangeRateMicro) &&
+            (identical(other.createdAt, createdAt) ||
+                other.createdAt == createdAt));
+  }
+
+  @override
+  int get hashCode => Object.hash(
+      runtimeType,
+      id,
+      transactionId,
+      accountId,
+      categoryId,
+      side,
+      amountMinor,
+      currencyCode,
+      exchangeRateMicro,
+      createdAt);
+
+  @override
+  String toString() {
+    return 'Entry(id: $id, transactionId: $transactionId, accountId: $accountId, categoryId: $categoryId, side: $side, amountMinor: $amountMinor, currencyCode: $currencyCode, exchangeRateMicro: $exchangeRateMicro, createdAt: $createdAt)';
+  }
+}
+
+/// @nodoc
+abstract mixin class $EntryCopyWith<$Res> {
+  factory $EntryCopyWith(Entry value, $Res Function(Entry) _then) =
+      _$EntryCopyWithImpl;
+  @useResult
+  $Res call(
+      {String id,
+      String transactionId,
+      String? accountId,
+      String? categoryId,
+      EntrySide side,
+      int amountMinor,
+      String currencyCode,
+      int? exchangeRateMicro,
+      int createdAt});
+}
+
+/// @nodoc
+class _$EntryCopyWithImpl<$Res> implements $EntryCopyWith<$Res> {
+  _$EntryCopyWithImpl(this._self, this._then);
+
+  final Entry _self;
+  final $Res Function(Entry) _then;
+
+  /// Create a copy of Entry
+  /// with the given fields replaced by the non-null parameter values.
+  @pragma('vm:prefer-inline')
+  @override
+  $Res call({
+    Object? id = null,
+    Object? transactionId = null,
+    Object? accountId = freezed,
+    Object? categoryId = freezed,
+    Object? side = null,
+    Object? amountMinor = null,
+    Object? currencyCode = null,
+    Object? exchangeRateMicro = freezed,
+    Object? createdAt = null,
+  }) {
+    return _then(_self.copyWith(
+      id: null == id
+          ? _self.id
+          : id // ignore: cast_nullable_to_non_nullable
+              as String,
+      transactionId: null == transactionId
+          ? _self.transactionId
+          : transactionId // ignore: cast_nullable_to_non_nullable
+              as String,
+      accountId: freezed == accountId
+          ? _self.accountId
+          : accountId // ignore: cast_nullable_to_non_nullable
+              as String?,
+      categoryId: freezed == categoryId
+          ? _self.categoryId
+          : categoryId // ignore: cast_nullable_to_non_nullable
+              as String?,
+      side: null == side
+          ? _self.side
+          : side // ignore: cast_nullable_to_non_nullable
+              as EntrySide,
+      amountMinor: null == amountMinor
+          ? _self.amountMinor
+          : amountMinor // ignore: cast_nullable_to_non_nullable
+              as int,
+      currencyCode: null == currencyCode
+          ? _self.currencyCode
+          : currencyCode // ignore: cast_nullable_to_non_nullable
+              as String,
+      exchangeRateMicro: freezed == exchangeRateMicro
+          ? _self.exchangeRateMicro
+          : exchangeRateMicro // ignore: cast_nullable_to_non_nullable
+              as int?,
+      createdAt: null == createdAt
+          ? _self.createdAt
+          : createdAt // ignore: cast_nullable_to_non_nullable
+              as int,
+    ));
+  }
+}
+
+/// Adds pattern-matching-related methods to [Entry].
+extension EntryPatterns on Entry {
+  /// A variant of `map` that fallback to returning `orElse`.
+  ///
+  /// It is equivalent to doing:
+  /// ```dart
+  /// switch (sealedClass) {
+  ///   case final Subclass value:
+  ///     return ...;
+  ///   case _:
+  ///     return orElse();
+  /// }
+  /// ```
+
+  @optionalTypeArgs
+  TResult maybeMap<TResult extends Object?>(
+    TResult Function(_Entry value)? $default, {
+    required TResult orElse(),
+  }) {
+    final _that = this;
+    switch (_that) {
+      case _Entry() when $default != null:
+        return $default(_that);
+      case _:
+        return orElse();
+    }
+  }
+
+  /// A `switch`-like method, using callbacks.
+  ///
+  /// Callbacks receives the raw object, upcasted.
+  /// It is equivalent to doing:
+  /// ```dart
+  /// switch (sealedClass) {
+  ///   case final Subclass value:
+  ///     return ...;
+  ///   case final Subclass2 value:
+  ///     return ...;
+  /// }
+  /// ```
+
+  @optionalTypeArgs
+  TResult map<TResult extends Object?>(
+    TResult Function(_Entry value) $default,
+  ) {
+    final _that = this;
+    switch (_that) {
+      case _Entry():
+        return $default(_that);
+      case _:
+        throw StateError('Unexpected subclass');
+    }
+  }
+
+  /// A variant of `map` that fallback to returning `null`.
+  ///
+  /// It is equivalent to doing:
+  /// ```dart
+  /// switch (sealedClass) {
+  ///   case final Subclass value:
+  ///     return ...;
+  ///   case _:
+  ///     return null;
+  /// }
+  /// ```
+
+  @optionalTypeArgs
+  TResult? mapOrNull<TResult extends Object?>(
+    TResult? Function(_Entry value)? $default,
+  ) {
+    final _that = this;
+    switch (_that) {
+      case _Entry() when $default != null:
+        return $default(_that);
+      case _:
+        return null;
+    }
+  }
+
+  /// A variant of `when` that fallback to an `orElse` callback.
+  ///
+  /// It is equivalent to doing:
+  /// ```dart
+  /// switch (sealedClass) {
+  ///   case Subclass(:final field):
+  ///     return ...;
+  ///   case _:
+  ///     return orElse();
+  /// }
+  /// ```
+
+  @optionalTypeArgs
+  TResult maybeWhen<TResult extends Object?>(
+    TResult Function(
+            String id,
+            String transactionId,
+            String? accountId,
+            String? categoryId,
+            EntrySide side,
+            int amountMinor,
+            String currencyCode,
+            int? exchangeRateMicro,
+            int createdAt)?
+        $default, {
+    required TResult orElse(),
+  }) {
+    final _that = this;
+    switch (_that) {
+      case _Entry() when $default != null:
+        return $default(
+            _that.id,
+            _that.transactionId,
+            _that.accountId,
+            _that.categoryId,
+            _that.side,
+            _that.amountMinor,
+            _that.currencyCode,
+            _that.exchangeRateMicro,
+            _that.createdAt);
+      case _:
+        return orElse();
+    }
+  }
+
+  /// A `switch`-like method, using callbacks.
+  ///
+  /// As opposed to `map`, this offers destructuring.
+  /// It is equivalent to doing:
+  /// ```dart
+  /// switch (sealedClass) {
+  ///   case Subclass(:final field):
+  ///     return ...;
+  ///   case Subclass2(:final field2):
+  ///     return ...;
+  /// }
+  /// ```
+
+  @optionalTypeArgs
+  TResult when<TResult extends Object?>(
+    TResult Function(
+            String id,
+            String transactionId,
+            String? accountId,
+            String? categoryId,
+            EntrySide side,
+            int amountMinor,
+            String currencyCode,
+            int? exchangeRateMicro,
+            int createdAt)
+        $default,
+  ) {
+    final _that = this;
+    switch (_that) {
+      case _Entry():
+        return $default(
+            _that.id,
+            _that.transactionId,
+            _that.accountId,
+            _that.categoryId,
+            _that.side,
+            _that.amountMinor,
+            _that.currencyCode,
+            _that.exchangeRateMicro,
+            _that.createdAt);
+      case _:
+        throw StateError('Unexpected subclass');
+    }
+  }
+
+  /// A variant of `when` that fallback to returning `null`
+  ///
+  /// It is equivalent to doing:
+  /// ```dart
+  /// switch (sealedClass) {
+  ///   case Subclass(:final field):
+  ///     return ...;
+  ///   case _:
+  ///     return null;
+  /// }
+  /// ```
+
+  @optionalTypeArgs
+  TResult? whenOrNull<TResult extends Object?>(
+    TResult? Function(
+            String id,
+            String transactionId,
+            String? accountId,
+            String? categoryId,
+            EntrySide side,
+            int amountMinor,
+            String currencyCode,
+            int? exchangeRateMicro,
+            int createdAt)?
+        $default,
+  ) {
+    final _that = this;
+    switch (_that) {
+      case _Entry() when $default != null:
+        return $default(
+            _that.id,
+            _that.transactionId,
+            _that.accountId,
+            _that.categoryId,
+            _that.side,
+            _that.amountMinor,
+            _that.currencyCode,
+            _that.exchangeRateMicro,
+            _that.createdAt);
+      case _:
+        return null;
+    }
+  }
+}
+
+/// @nodoc
+
+class _Entry implements Entry {
+  const _Entry(
+      {required this.id,
+      required this.transactionId,
+      this.accountId,
+      this.categoryId,
+      required this.side,
+      required this.amountMinor,
+      required this.currencyCode,
+      this.exchangeRateMicro,
+      required this.createdAt});
+
+  /// UUID v4 stable identifier.
+  @override
+  final String id;
+
+  /// Parent transaction UUID.
+  @override
+  final String transactionId;
+
+  /// Account leg — mutually exclusive with [categoryId].
+  @override
+  final String? accountId;
+
+  /// Category leg — mutually exclusive with [accountId].
+  @override
+  final String? categoryId;
+
+  /// DEB side of this entry.
+  @override
+  final EntrySide side;
+
+  /// Amount in minor units of [currencyCode].
+  @override
+  final int amountMinor;
+
+  /// ISO 4217 currency code of this entry.
+  @override
+  final String currencyCode;
+
+  /// Rate to home currency × 1,000,000; null if same as home currency.
+  @override
+  final int? exchangeRateMicro;
+
+  /// System write epoch (TC-025).
+  @override
+  final int createdAt;
+
+  /// Create a copy of Entry
+  /// with the given fields replaced by the non-null parameter values.
+  @override
+  @JsonKey(includeFromJson: false, includeToJson: false)
+  @pragma('vm:prefer-inline')
+  _$EntryCopyWith<_Entry> get copyWith =>
+      __$EntryCopyWithImpl<_Entry>(this, _$identity);
+
+  @override
+  bool operator ==(Object other) {
+    return identical(this, other) ||
+        (other.runtimeType == runtimeType &&
+            other is _Entry &&
+            (identical(other.id, id) || other.id == id) &&
+            (identical(other.transactionId, transactionId) ||
+                other.transactionId == transactionId) &&
+            (identical(other.accountId, accountId) ||
+                other.accountId == accountId) &&
+            (identical(other.categoryId, categoryId) ||
+                other.categoryId == categoryId) &&
+            (identical(other.side, side) || other.side == side) &&
+            (identical(other.amountMinor, amountMinor) ||
+                other.amountMinor == amountMinor) &&
+            (identical(other.currencyCode, currencyCode) ||
+                other.currencyCode == currencyCode) &&
+            (identical(other.exchangeRateMicro, exchangeRateMicro) ||
+                other.exchangeRateMicro == exchangeRateMicro) &&
+            (identical(other.createdAt, createdAt) ||
+                other.createdAt == createdAt));
+  }
+
+  @override
+  int get hashCode => Object.hash(
+      runtimeType,
+      id,
+      transactionId,
+      accountId,
+      categoryId,
+      side,
+      amountMinor,
+      currencyCode,
+      exchangeRateMicro,
+      createdAt);
+
+  @override
+  String toString() {
+    return 'Entry(id: $id, transactionId: $transactionId, accountId: $accountId, categoryId: $categoryId, side: $side, amountMinor: $amountMinor, currencyCode: $currencyCode, exchangeRateMicro: $exchangeRateMicro, createdAt: $createdAt)';
+  }
+}
+
+/// @nodoc
+abstract mixin class _$EntryCopyWith<$Res> implements $EntryCopyWith<$Res> {
+  factory _$EntryCopyWith(_Entry value, $Res Function(_Entry) _then) =
+      __$EntryCopyWithImpl;
+  @override
+  @useResult
+  $Res call(
+      {String id,
+      String transactionId,
+      String? accountId,
+      String? categoryId,
+      EntrySide side,
+      int amountMinor,
+      String currencyCode,
+      int? exchangeRateMicro,
+      int createdAt});
+}
+
+/// @nodoc
+class __$EntryCopyWithImpl<$Res> implements _$EntryCopyWith<$Res> {
+  __$EntryCopyWithImpl(this._self, this._then);
+
+  final _Entry _self;
+  final $Res Function(_Entry) _then;
+
+  /// Create a copy of Entry
+  /// with the given fields replaced by the non-null parameter values.
+  @override
+  @pragma('vm:prefer-inline')
+  $Res call({
+    Object? id = null,
+    Object? transactionId = null,
+    Object? accountId = freezed,
+    Object? categoryId = freezed,
+    Object? side = null,
+    Object? amountMinor = null,
+    Object? currencyCode = null,
+    Object? exchangeRateMicro = freezed,
+    Object? createdAt = null,
+  }) {
+    return _then(_Entry(
+      id: null == id
+          ? _self.id
+          : id // ignore: cast_nullable_to_non_nullable
+              as String,
+      transactionId: null == transactionId
+          ? _self.transactionId
+          : transactionId // ignore: cast_nullable_to_non_nullable
+              as String,
+      accountId: freezed == accountId
+          ? _self.accountId
+          : accountId // ignore: cast_nullable_to_non_nullable
+              as String?,
+      categoryId: freezed == categoryId
+          ? _self.categoryId
+          : categoryId // ignore: cast_nullable_to_non_nullable
+              as String?,
+      side: null == side
+          ? _self.side
+          : side // ignore: cast_nullable_to_non_nullable
+              as EntrySide,
+      amountMinor: null == amountMinor
+          ? _self.amountMinor
+          : amountMinor // ignore: cast_nullable_to_non_nullable
+              as int,
+      currencyCode: null == currencyCode
+          ? _self.currencyCode
+          : currencyCode // ignore: cast_nullable_to_non_nullable
+              as String,
+      exchangeRateMicro: freezed == exchangeRateMicro
+          ? _self.exchangeRateMicro
+          : exchangeRateMicro // ignore: cast_nullable_to_non_nullable
+              as int?,
+      createdAt: null == createdAt
+          ? _self.createdAt
+          : createdAt // ignore: cast_nullable_to_non_nullable
+              as int,
+    ));
+  }
+}
+
+// dart format on

--- a/lib/domain/entities/exchange_rate.dart
+++ b/lib/domain/entities/exchange_rate.dart
@@ -1,0 +1,36 @@
+// lib/domain/entities/exchange_rate.dart
+//
+// ExchangeRate domain entity.
+//
+// Cached exchange rate pair from the fawazahmed0 API. Upserted on each
+// successful fetch. Staleness threshold: 14 days (SDS §2.7).
+//
+// Rate precision: stored as INTEGER micro units (rate × 1,000,000).
+
+import 'package:freezed_annotation/freezed_annotation.dart';
+
+part 'exchange_rate.freezed.dart';
+
+/// Immutable domain entity for a cached currency exchange rate.
+@freezed
+abstract class ExchangeRate with _$ExchangeRate {
+  const factory ExchangeRate({
+    /// Row identifier (auto-increment, not UUID, per data model §4.2).
+    required int id,
+
+    /// Base currency ISO 4217 code.
+    required String fromCurrency,
+
+    /// Target currency ISO 4217 code.
+    required String toCurrency,
+
+    /// Exchange rate × 1,000,000 (6 decimal precision).
+    required int rateMicro,
+
+    /// Wall-clock epoch when the rate was fetched from the API.
+    required int fetchedAt,
+
+    /// Publication date from the API `date` field (ISO 8601, e.g. '2025-05-07').
+    required String rateDate,
+  }) = _ExchangeRate;
+}

--- a/lib/domain/entities/exchange_rate.freezed.dart
+++ b/lib/domain/entities/exchange_rate.freezed.dart
@@ -1,0 +1,437 @@
+// GENERATED CODE - DO NOT MODIFY BY HAND
+// coverage:ignore-file
+// ignore_for_file: type=lint
+// ignore_for_file: unused_element, deprecated_member_use, deprecated_member_use_from_same_package, use_function_type_syntax_for_parameters, unnecessary_const, avoid_init_to_null, invalid_override_different_default_values_named, prefer_expression_function_bodies, annotate_overrides, invalid_annotation_target, unnecessary_question_mark
+
+part of 'exchange_rate.dart';
+
+// **************************************************************************
+// FreezedGenerator
+// **************************************************************************
+
+// dart format off
+T _$identity<T>(T value) => value;
+
+/// @nodoc
+mixin _$ExchangeRate {
+  /// Row identifier (auto-increment, not UUID, per data model §4.2).
+  int get id;
+
+  /// Base currency ISO 4217 code.
+  String get fromCurrency;
+
+  /// Target currency ISO 4217 code.
+  String get toCurrency;
+
+  /// Exchange rate × 1,000,000 (6 decimal precision).
+  int get rateMicro;
+
+  /// Wall-clock epoch when the rate was fetched from the API.
+  int get fetchedAt;
+
+  /// Publication date from the API `date` field (ISO 8601, e.g. '2025-05-07').
+  String get rateDate;
+
+  /// Create a copy of ExchangeRate
+  /// with the given fields replaced by the non-null parameter values.
+  @JsonKey(includeFromJson: false, includeToJson: false)
+  @pragma('vm:prefer-inline')
+  $ExchangeRateCopyWith<ExchangeRate> get copyWith =>
+      _$ExchangeRateCopyWithImpl<ExchangeRate>(
+          this as ExchangeRate, _$identity);
+
+  @override
+  bool operator ==(Object other) {
+    return identical(this, other) ||
+        (other.runtimeType == runtimeType &&
+            other is ExchangeRate &&
+            (identical(other.id, id) || other.id == id) &&
+            (identical(other.fromCurrency, fromCurrency) ||
+                other.fromCurrency == fromCurrency) &&
+            (identical(other.toCurrency, toCurrency) ||
+                other.toCurrency == toCurrency) &&
+            (identical(other.rateMicro, rateMicro) ||
+                other.rateMicro == rateMicro) &&
+            (identical(other.fetchedAt, fetchedAt) ||
+                other.fetchedAt == fetchedAt) &&
+            (identical(other.rateDate, rateDate) ||
+                other.rateDate == rateDate));
+  }
+
+  @override
+  int get hashCode => Object.hash(runtimeType, id, fromCurrency, toCurrency,
+      rateMicro, fetchedAt, rateDate);
+
+  @override
+  String toString() {
+    return 'ExchangeRate(id: $id, fromCurrency: $fromCurrency, toCurrency: $toCurrency, rateMicro: $rateMicro, fetchedAt: $fetchedAt, rateDate: $rateDate)';
+  }
+}
+
+/// @nodoc
+abstract mixin class $ExchangeRateCopyWith<$Res> {
+  factory $ExchangeRateCopyWith(
+          ExchangeRate value, $Res Function(ExchangeRate) _then) =
+      _$ExchangeRateCopyWithImpl;
+  @useResult
+  $Res call(
+      {int id,
+      String fromCurrency,
+      String toCurrency,
+      int rateMicro,
+      int fetchedAt,
+      String rateDate});
+}
+
+/// @nodoc
+class _$ExchangeRateCopyWithImpl<$Res> implements $ExchangeRateCopyWith<$Res> {
+  _$ExchangeRateCopyWithImpl(this._self, this._then);
+
+  final ExchangeRate _self;
+  final $Res Function(ExchangeRate) _then;
+
+  /// Create a copy of ExchangeRate
+  /// with the given fields replaced by the non-null parameter values.
+  @pragma('vm:prefer-inline')
+  @override
+  $Res call({
+    Object? id = null,
+    Object? fromCurrency = null,
+    Object? toCurrency = null,
+    Object? rateMicro = null,
+    Object? fetchedAt = null,
+    Object? rateDate = null,
+  }) {
+    return _then(_self.copyWith(
+      id: null == id
+          ? _self.id
+          : id // ignore: cast_nullable_to_non_nullable
+              as int,
+      fromCurrency: null == fromCurrency
+          ? _self.fromCurrency
+          : fromCurrency // ignore: cast_nullable_to_non_nullable
+              as String,
+      toCurrency: null == toCurrency
+          ? _self.toCurrency
+          : toCurrency // ignore: cast_nullable_to_non_nullable
+              as String,
+      rateMicro: null == rateMicro
+          ? _self.rateMicro
+          : rateMicro // ignore: cast_nullable_to_non_nullable
+              as int,
+      fetchedAt: null == fetchedAt
+          ? _self.fetchedAt
+          : fetchedAt // ignore: cast_nullable_to_non_nullable
+              as int,
+      rateDate: null == rateDate
+          ? _self.rateDate
+          : rateDate // ignore: cast_nullable_to_non_nullable
+              as String,
+    ));
+  }
+}
+
+/// Adds pattern-matching-related methods to [ExchangeRate].
+extension ExchangeRatePatterns on ExchangeRate {
+  /// A variant of `map` that fallback to returning `orElse`.
+  ///
+  /// It is equivalent to doing:
+  /// ```dart
+  /// switch (sealedClass) {
+  ///   case final Subclass value:
+  ///     return ...;
+  ///   case _:
+  ///     return orElse();
+  /// }
+  /// ```
+
+  @optionalTypeArgs
+  TResult maybeMap<TResult extends Object?>(
+    TResult Function(_ExchangeRate value)? $default, {
+    required TResult orElse(),
+  }) {
+    final _that = this;
+    switch (_that) {
+      case _ExchangeRate() when $default != null:
+        return $default(_that);
+      case _:
+        return orElse();
+    }
+  }
+
+  /// A `switch`-like method, using callbacks.
+  ///
+  /// Callbacks receives the raw object, upcasted.
+  /// It is equivalent to doing:
+  /// ```dart
+  /// switch (sealedClass) {
+  ///   case final Subclass value:
+  ///     return ...;
+  ///   case final Subclass2 value:
+  ///     return ...;
+  /// }
+  /// ```
+
+  @optionalTypeArgs
+  TResult map<TResult extends Object?>(
+    TResult Function(_ExchangeRate value) $default,
+  ) {
+    final _that = this;
+    switch (_that) {
+      case _ExchangeRate():
+        return $default(_that);
+      case _:
+        throw StateError('Unexpected subclass');
+    }
+  }
+
+  /// A variant of `map` that fallback to returning `null`.
+  ///
+  /// It is equivalent to doing:
+  /// ```dart
+  /// switch (sealedClass) {
+  ///   case final Subclass value:
+  ///     return ...;
+  ///   case _:
+  ///     return null;
+  /// }
+  /// ```
+
+  @optionalTypeArgs
+  TResult? mapOrNull<TResult extends Object?>(
+    TResult? Function(_ExchangeRate value)? $default,
+  ) {
+    final _that = this;
+    switch (_that) {
+      case _ExchangeRate() when $default != null:
+        return $default(_that);
+      case _:
+        return null;
+    }
+  }
+
+  /// A variant of `when` that fallback to an `orElse` callback.
+  ///
+  /// It is equivalent to doing:
+  /// ```dart
+  /// switch (sealedClass) {
+  ///   case Subclass(:final field):
+  ///     return ...;
+  ///   case _:
+  ///     return orElse();
+  /// }
+  /// ```
+
+  @optionalTypeArgs
+  TResult maybeWhen<TResult extends Object?>(
+    TResult Function(int id, String fromCurrency, String toCurrency,
+            int rateMicro, int fetchedAt, String rateDate)?
+        $default, {
+    required TResult orElse(),
+  }) {
+    final _that = this;
+    switch (_that) {
+      case _ExchangeRate() when $default != null:
+        return $default(_that.id, _that.fromCurrency, _that.toCurrency,
+            _that.rateMicro, _that.fetchedAt, _that.rateDate);
+      case _:
+        return orElse();
+    }
+  }
+
+  /// A `switch`-like method, using callbacks.
+  ///
+  /// As opposed to `map`, this offers destructuring.
+  /// It is equivalent to doing:
+  /// ```dart
+  /// switch (sealedClass) {
+  ///   case Subclass(:final field):
+  ///     return ...;
+  ///   case Subclass2(:final field2):
+  ///     return ...;
+  /// }
+  /// ```
+
+  @optionalTypeArgs
+  TResult when<TResult extends Object?>(
+    TResult Function(int id, String fromCurrency, String toCurrency,
+            int rateMicro, int fetchedAt, String rateDate)
+        $default,
+  ) {
+    final _that = this;
+    switch (_that) {
+      case _ExchangeRate():
+        return $default(_that.id, _that.fromCurrency, _that.toCurrency,
+            _that.rateMicro, _that.fetchedAt, _that.rateDate);
+      case _:
+        throw StateError('Unexpected subclass');
+    }
+  }
+
+  /// A variant of `when` that fallback to returning `null`
+  ///
+  /// It is equivalent to doing:
+  /// ```dart
+  /// switch (sealedClass) {
+  ///   case Subclass(:final field):
+  ///     return ...;
+  ///   case _:
+  ///     return null;
+  /// }
+  /// ```
+
+  @optionalTypeArgs
+  TResult? whenOrNull<TResult extends Object?>(
+    TResult? Function(int id, String fromCurrency, String toCurrency,
+            int rateMicro, int fetchedAt, String rateDate)?
+        $default,
+  ) {
+    final _that = this;
+    switch (_that) {
+      case _ExchangeRate() when $default != null:
+        return $default(_that.id, _that.fromCurrency, _that.toCurrency,
+            _that.rateMicro, _that.fetchedAt, _that.rateDate);
+      case _:
+        return null;
+    }
+  }
+}
+
+/// @nodoc
+
+class _ExchangeRate implements ExchangeRate {
+  const _ExchangeRate(
+      {required this.id,
+      required this.fromCurrency,
+      required this.toCurrency,
+      required this.rateMicro,
+      required this.fetchedAt,
+      required this.rateDate});
+
+  /// Row identifier (auto-increment, not UUID, per data model §4.2).
+  @override
+  final int id;
+
+  /// Base currency ISO 4217 code.
+  @override
+  final String fromCurrency;
+
+  /// Target currency ISO 4217 code.
+  @override
+  final String toCurrency;
+
+  /// Exchange rate × 1,000,000 (6 decimal precision).
+  @override
+  final int rateMicro;
+
+  /// Wall-clock epoch when the rate was fetched from the API.
+  @override
+  final int fetchedAt;
+
+  /// Publication date from the API `date` field (ISO 8601, e.g. '2025-05-07').
+  @override
+  final String rateDate;
+
+  /// Create a copy of ExchangeRate
+  /// with the given fields replaced by the non-null parameter values.
+  @override
+  @JsonKey(includeFromJson: false, includeToJson: false)
+  @pragma('vm:prefer-inline')
+  _$ExchangeRateCopyWith<_ExchangeRate> get copyWith =>
+      __$ExchangeRateCopyWithImpl<_ExchangeRate>(this, _$identity);
+
+  @override
+  bool operator ==(Object other) {
+    return identical(this, other) ||
+        (other.runtimeType == runtimeType &&
+            other is _ExchangeRate &&
+            (identical(other.id, id) || other.id == id) &&
+            (identical(other.fromCurrency, fromCurrency) ||
+                other.fromCurrency == fromCurrency) &&
+            (identical(other.toCurrency, toCurrency) ||
+                other.toCurrency == toCurrency) &&
+            (identical(other.rateMicro, rateMicro) ||
+                other.rateMicro == rateMicro) &&
+            (identical(other.fetchedAt, fetchedAt) ||
+                other.fetchedAt == fetchedAt) &&
+            (identical(other.rateDate, rateDate) ||
+                other.rateDate == rateDate));
+  }
+
+  @override
+  int get hashCode => Object.hash(runtimeType, id, fromCurrency, toCurrency,
+      rateMicro, fetchedAt, rateDate);
+
+  @override
+  String toString() {
+    return 'ExchangeRate(id: $id, fromCurrency: $fromCurrency, toCurrency: $toCurrency, rateMicro: $rateMicro, fetchedAt: $fetchedAt, rateDate: $rateDate)';
+  }
+}
+
+/// @nodoc
+abstract mixin class _$ExchangeRateCopyWith<$Res>
+    implements $ExchangeRateCopyWith<$Res> {
+  factory _$ExchangeRateCopyWith(
+          _ExchangeRate value, $Res Function(_ExchangeRate) _then) =
+      __$ExchangeRateCopyWithImpl;
+  @override
+  @useResult
+  $Res call(
+      {int id,
+      String fromCurrency,
+      String toCurrency,
+      int rateMicro,
+      int fetchedAt,
+      String rateDate});
+}
+
+/// @nodoc
+class __$ExchangeRateCopyWithImpl<$Res>
+    implements _$ExchangeRateCopyWith<$Res> {
+  __$ExchangeRateCopyWithImpl(this._self, this._then);
+
+  final _ExchangeRate _self;
+  final $Res Function(_ExchangeRate) _then;
+
+  /// Create a copy of ExchangeRate
+  /// with the given fields replaced by the non-null parameter values.
+  @override
+  @pragma('vm:prefer-inline')
+  $Res call({
+    Object? id = null,
+    Object? fromCurrency = null,
+    Object? toCurrency = null,
+    Object? rateMicro = null,
+    Object? fetchedAt = null,
+    Object? rateDate = null,
+  }) {
+    return _then(_ExchangeRate(
+      id: null == id
+          ? _self.id
+          : id // ignore: cast_nullable_to_non_nullable
+              as int,
+      fromCurrency: null == fromCurrency
+          ? _self.fromCurrency
+          : fromCurrency // ignore: cast_nullable_to_non_nullable
+              as String,
+      toCurrency: null == toCurrency
+          ? _self.toCurrency
+          : toCurrency // ignore: cast_nullable_to_non_nullable
+              as String,
+      rateMicro: null == rateMicro
+          ? _self.rateMicro
+          : rateMicro // ignore: cast_nullable_to_non_nullable
+              as int,
+      fetchedAt: null == fetchedAt
+          ? _self.fetchedAt
+          : fetchedAt // ignore: cast_nullable_to_non_nullable
+              as int,
+      rateDate: null == rateDate
+          ? _self.rateDate
+          : rateDate // ignore: cast_nullable_to_non_nullable
+              as String,
+    ));
+  }
+}
+
+// dart format on

--- a/lib/domain/entities/installment_occurrence.dart
+++ b/lib/domain/entities/installment_occurrence.dart
@@ -1,0 +1,53 @@
+// lib/domain/entities/installment_occurrence.dart
+//
+// InstallmentOccurrence domain entity.
+//
+// Individual materialized installment record. Created eagerly at template
+// creation (all occurrences). Supports per-installment amount overrides
+// and status tracking.
+
+import 'package:freezed_annotation/freezed_annotation.dart';
+
+part 'installment_occurrence.freezed.dart';
+
+/// Lifecycle state of an installment occurrence.
+enum InstallmentOccurrenceStatus {
+  pending,
+  posted,
+  cancelled,
+}
+
+/// Immutable domain entity for a single installment occurrence.
+@freezed
+abstract class InstallmentOccurrence with _$InstallmentOccurrence {
+  const factory InstallmentOccurrence({
+    /// UUID v4 stable identifier.
+    required String id,
+
+    /// Parent installment template UUID.
+    required String templateId,
+
+    /// 1-based position in the installment series; unique per template.
+    required int sequenceNumber,
+
+    /// Unix epoch date when this installment should be posted.
+    required int scheduledDate,
+
+    /// Per-installment amount in minor units; user-adjustable for future
+    /// unposted installments.
+    required int amountMinor,
+
+    /// Lifecycle status.
+    @Default(InstallmentOccurrenceStatus.pending)
+    InstallmentOccurrenceStatus status,
+
+    /// Transaction UUID once the installment is posted.
+    String? childTransactionId,
+
+    /// Creation epoch (Unix seconds).
+    required int createdAt,
+
+    /// Last-modified epoch (Unix seconds).
+    required int updatedAt,
+  }) = _InstallmentOccurrence;
+}

--- a/lib/domain/entities/installment_occurrence.freezed.dart
+++ b/lib/domain/entities/installment_occurrence.freezed.dart
@@ -1,0 +1,578 @@
+// GENERATED CODE - DO NOT MODIFY BY HAND
+// coverage:ignore-file
+// ignore_for_file: type=lint
+// ignore_for_file: unused_element, deprecated_member_use, deprecated_member_use_from_same_package, use_function_type_syntax_for_parameters, unnecessary_const, avoid_init_to_null, invalid_override_different_default_values_named, prefer_expression_function_bodies, annotate_overrides, invalid_annotation_target, unnecessary_question_mark
+
+part of 'installment_occurrence.dart';
+
+// **************************************************************************
+// FreezedGenerator
+// **************************************************************************
+
+// dart format off
+T _$identity<T>(T value) => value;
+
+/// @nodoc
+mixin _$InstallmentOccurrence {
+  /// UUID v4 stable identifier.
+  String get id;
+
+  /// Parent installment template UUID.
+  String get templateId;
+
+  /// 1-based position in the installment series; unique per template.
+  int get sequenceNumber;
+
+  /// Unix epoch date when this installment should be posted.
+  int get scheduledDate;
+
+  /// Per-installment amount in minor units; user-adjustable for future
+  /// unposted installments.
+  int get amountMinor;
+
+  /// Lifecycle status.
+  InstallmentOccurrenceStatus get status;
+
+  /// Transaction UUID once the installment is posted.
+  String? get childTransactionId;
+
+  /// Creation epoch (Unix seconds).
+  int get createdAt;
+
+  /// Last-modified epoch (Unix seconds).
+  int get updatedAt;
+
+  /// Create a copy of InstallmentOccurrence
+  /// with the given fields replaced by the non-null parameter values.
+  @JsonKey(includeFromJson: false, includeToJson: false)
+  @pragma('vm:prefer-inline')
+  $InstallmentOccurrenceCopyWith<InstallmentOccurrence> get copyWith =>
+      _$InstallmentOccurrenceCopyWithImpl<InstallmentOccurrence>(
+          this as InstallmentOccurrence, _$identity);
+
+  @override
+  bool operator ==(Object other) {
+    return identical(this, other) ||
+        (other.runtimeType == runtimeType &&
+            other is InstallmentOccurrence &&
+            (identical(other.id, id) || other.id == id) &&
+            (identical(other.templateId, templateId) ||
+                other.templateId == templateId) &&
+            (identical(other.sequenceNumber, sequenceNumber) ||
+                other.sequenceNumber == sequenceNumber) &&
+            (identical(other.scheduledDate, scheduledDate) ||
+                other.scheduledDate == scheduledDate) &&
+            (identical(other.amountMinor, amountMinor) ||
+                other.amountMinor == amountMinor) &&
+            (identical(other.status, status) || other.status == status) &&
+            (identical(other.childTransactionId, childTransactionId) ||
+                other.childTransactionId == childTransactionId) &&
+            (identical(other.createdAt, createdAt) ||
+                other.createdAt == createdAt) &&
+            (identical(other.updatedAt, updatedAt) ||
+                other.updatedAt == updatedAt));
+  }
+
+  @override
+  int get hashCode => Object.hash(
+      runtimeType,
+      id,
+      templateId,
+      sequenceNumber,
+      scheduledDate,
+      amountMinor,
+      status,
+      childTransactionId,
+      createdAt,
+      updatedAt);
+
+  @override
+  String toString() {
+    return 'InstallmentOccurrence(id: $id, templateId: $templateId, sequenceNumber: $sequenceNumber, scheduledDate: $scheduledDate, amountMinor: $amountMinor, status: $status, childTransactionId: $childTransactionId, createdAt: $createdAt, updatedAt: $updatedAt)';
+  }
+}
+
+/// @nodoc
+abstract mixin class $InstallmentOccurrenceCopyWith<$Res> {
+  factory $InstallmentOccurrenceCopyWith(InstallmentOccurrence value,
+          $Res Function(InstallmentOccurrence) _then) =
+      _$InstallmentOccurrenceCopyWithImpl;
+  @useResult
+  $Res call(
+      {String id,
+      String templateId,
+      int sequenceNumber,
+      int scheduledDate,
+      int amountMinor,
+      InstallmentOccurrenceStatus status,
+      String? childTransactionId,
+      int createdAt,
+      int updatedAt});
+}
+
+/// @nodoc
+class _$InstallmentOccurrenceCopyWithImpl<$Res>
+    implements $InstallmentOccurrenceCopyWith<$Res> {
+  _$InstallmentOccurrenceCopyWithImpl(this._self, this._then);
+
+  final InstallmentOccurrence _self;
+  final $Res Function(InstallmentOccurrence) _then;
+
+  /// Create a copy of InstallmentOccurrence
+  /// with the given fields replaced by the non-null parameter values.
+  @pragma('vm:prefer-inline')
+  @override
+  $Res call({
+    Object? id = null,
+    Object? templateId = null,
+    Object? sequenceNumber = null,
+    Object? scheduledDate = null,
+    Object? amountMinor = null,
+    Object? status = null,
+    Object? childTransactionId = freezed,
+    Object? createdAt = null,
+    Object? updatedAt = null,
+  }) {
+    return _then(_self.copyWith(
+      id: null == id
+          ? _self.id
+          : id // ignore: cast_nullable_to_non_nullable
+              as String,
+      templateId: null == templateId
+          ? _self.templateId
+          : templateId // ignore: cast_nullable_to_non_nullable
+              as String,
+      sequenceNumber: null == sequenceNumber
+          ? _self.sequenceNumber
+          : sequenceNumber // ignore: cast_nullable_to_non_nullable
+              as int,
+      scheduledDate: null == scheduledDate
+          ? _self.scheduledDate
+          : scheduledDate // ignore: cast_nullable_to_non_nullable
+              as int,
+      amountMinor: null == amountMinor
+          ? _self.amountMinor
+          : amountMinor // ignore: cast_nullable_to_non_nullable
+              as int,
+      status: null == status
+          ? _self.status
+          : status // ignore: cast_nullable_to_non_nullable
+              as InstallmentOccurrenceStatus,
+      childTransactionId: freezed == childTransactionId
+          ? _self.childTransactionId
+          : childTransactionId // ignore: cast_nullable_to_non_nullable
+              as String?,
+      createdAt: null == createdAt
+          ? _self.createdAt
+          : createdAt // ignore: cast_nullable_to_non_nullable
+              as int,
+      updatedAt: null == updatedAt
+          ? _self.updatedAt
+          : updatedAt // ignore: cast_nullable_to_non_nullable
+              as int,
+    ));
+  }
+}
+
+/// Adds pattern-matching-related methods to [InstallmentOccurrence].
+extension InstallmentOccurrencePatterns on InstallmentOccurrence {
+  /// A variant of `map` that fallback to returning `orElse`.
+  ///
+  /// It is equivalent to doing:
+  /// ```dart
+  /// switch (sealedClass) {
+  ///   case final Subclass value:
+  ///     return ...;
+  ///   case _:
+  ///     return orElse();
+  /// }
+  /// ```
+
+  @optionalTypeArgs
+  TResult maybeMap<TResult extends Object?>(
+    TResult Function(_InstallmentOccurrence value)? $default, {
+    required TResult orElse(),
+  }) {
+    final _that = this;
+    switch (_that) {
+      case _InstallmentOccurrence() when $default != null:
+        return $default(_that);
+      case _:
+        return orElse();
+    }
+  }
+
+  /// A `switch`-like method, using callbacks.
+  ///
+  /// Callbacks receives the raw object, upcasted.
+  /// It is equivalent to doing:
+  /// ```dart
+  /// switch (sealedClass) {
+  ///   case final Subclass value:
+  ///     return ...;
+  ///   case final Subclass2 value:
+  ///     return ...;
+  /// }
+  /// ```
+
+  @optionalTypeArgs
+  TResult map<TResult extends Object?>(
+    TResult Function(_InstallmentOccurrence value) $default,
+  ) {
+    final _that = this;
+    switch (_that) {
+      case _InstallmentOccurrence():
+        return $default(_that);
+      case _:
+        throw StateError('Unexpected subclass');
+    }
+  }
+
+  /// A variant of `map` that fallback to returning `null`.
+  ///
+  /// It is equivalent to doing:
+  /// ```dart
+  /// switch (sealedClass) {
+  ///   case final Subclass value:
+  ///     return ...;
+  ///   case _:
+  ///     return null;
+  /// }
+  /// ```
+
+  @optionalTypeArgs
+  TResult? mapOrNull<TResult extends Object?>(
+    TResult? Function(_InstallmentOccurrence value)? $default,
+  ) {
+    final _that = this;
+    switch (_that) {
+      case _InstallmentOccurrence() when $default != null:
+        return $default(_that);
+      case _:
+        return null;
+    }
+  }
+
+  /// A variant of `when` that fallback to an `orElse` callback.
+  ///
+  /// It is equivalent to doing:
+  /// ```dart
+  /// switch (sealedClass) {
+  ///   case Subclass(:final field):
+  ///     return ...;
+  ///   case _:
+  ///     return orElse();
+  /// }
+  /// ```
+
+  @optionalTypeArgs
+  TResult maybeWhen<TResult extends Object?>(
+    TResult Function(
+            String id,
+            String templateId,
+            int sequenceNumber,
+            int scheduledDate,
+            int amountMinor,
+            InstallmentOccurrenceStatus status,
+            String? childTransactionId,
+            int createdAt,
+            int updatedAt)?
+        $default, {
+    required TResult orElse(),
+  }) {
+    final _that = this;
+    switch (_that) {
+      case _InstallmentOccurrence() when $default != null:
+        return $default(
+            _that.id,
+            _that.templateId,
+            _that.sequenceNumber,
+            _that.scheduledDate,
+            _that.amountMinor,
+            _that.status,
+            _that.childTransactionId,
+            _that.createdAt,
+            _that.updatedAt);
+      case _:
+        return orElse();
+    }
+  }
+
+  /// A `switch`-like method, using callbacks.
+  ///
+  /// As opposed to `map`, this offers destructuring.
+  /// It is equivalent to doing:
+  /// ```dart
+  /// switch (sealedClass) {
+  ///   case Subclass(:final field):
+  ///     return ...;
+  ///   case Subclass2(:final field2):
+  ///     return ...;
+  /// }
+  /// ```
+
+  @optionalTypeArgs
+  TResult when<TResult extends Object?>(
+    TResult Function(
+            String id,
+            String templateId,
+            int sequenceNumber,
+            int scheduledDate,
+            int amountMinor,
+            InstallmentOccurrenceStatus status,
+            String? childTransactionId,
+            int createdAt,
+            int updatedAt)
+        $default,
+  ) {
+    final _that = this;
+    switch (_that) {
+      case _InstallmentOccurrence():
+        return $default(
+            _that.id,
+            _that.templateId,
+            _that.sequenceNumber,
+            _that.scheduledDate,
+            _that.amountMinor,
+            _that.status,
+            _that.childTransactionId,
+            _that.createdAt,
+            _that.updatedAt);
+      case _:
+        throw StateError('Unexpected subclass');
+    }
+  }
+
+  /// A variant of `when` that fallback to returning `null`
+  ///
+  /// It is equivalent to doing:
+  /// ```dart
+  /// switch (sealedClass) {
+  ///   case Subclass(:final field):
+  ///     return ...;
+  ///   case _:
+  ///     return null;
+  /// }
+  /// ```
+
+  @optionalTypeArgs
+  TResult? whenOrNull<TResult extends Object?>(
+    TResult? Function(
+            String id,
+            String templateId,
+            int sequenceNumber,
+            int scheduledDate,
+            int amountMinor,
+            InstallmentOccurrenceStatus status,
+            String? childTransactionId,
+            int createdAt,
+            int updatedAt)?
+        $default,
+  ) {
+    final _that = this;
+    switch (_that) {
+      case _InstallmentOccurrence() when $default != null:
+        return $default(
+            _that.id,
+            _that.templateId,
+            _that.sequenceNumber,
+            _that.scheduledDate,
+            _that.amountMinor,
+            _that.status,
+            _that.childTransactionId,
+            _that.createdAt,
+            _that.updatedAt);
+      case _:
+        return null;
+    }
+  }
+}
+
+/// @nodoc
+
+class _InstallmentOccurrence implements InstallmentOccurrence {
+  const _InstallmentOccurrence(
+      {required this.id,
+      required this.templateId,
+      required this.sequenceNumber,
+      required this.scheduledDate,
+      required this.amountMinor,
+      this.status = InstallmentOccurrenceStatus.pending,
+      this.childTransactionId,
+      required this.createdAt,
+      required this.updatedAt});
+
+  /// UUID v4 stable identifier.
+  @override
+  final String id;
+
+  /// Parent installment template UUID.
+  @override
+  final String templateId;
+
+  /// 1-based position in the installment series; unique per template.
+  @override
+  final int sequenceNumber;
+
+  /// Unix epoch date when this installment should be posted.
+  @override
+  final int scheduledDate;
+
+  /// Per-installment amount in minor units; user-adjustable for future
+  /// unposted installments.
+  @override
+  final int amountMinor;
+
+  /// Lifecycle status.
+  @override
+  @JsonKey()
+  final InstallmentOccurrenceStatus status;
+
+  /// Transaction UUID once the installment is posted.
+  @override
+  final String? childTransactionId;
+
+  /// Creation epoch (Unix seconds).
+  @override
+  final int createdAt;
+
+  /// Last-modified epoch (Unix seconds).
+  @override
+  final int updatedAt;
+
+  /// Create a copy of InstallmentOccurrence
+  /// with the given fields replaced by the non-null parameter values.
+  @override
+  @JsonKey(includeFromJson: false, includeToJson: false)
+  @pragma('vm:prefer-inline')
+  _$InstallmentOccurrenceCopyWith<_InstallmentOccurrence> get copyWith =>
+      __$InstallmentOccurrenceCopyWithImpl<_InstallmentOccurrence>(
+          this, _$identity);
+
+  @override
+  bool operator ==(Object other) {
+    return identical(this, other) ||
+        (other.runtimeType == runtimeType &&
+            other is _InstallmentOccurrence &&
+            (identical(other.id, id) || other.id == id) &&
+            (identical(other.templateId, templateId) ||
+                other.templateId == templateId) &&
+            (identical(other.sequenceNumber, sequenceNumber) ||
+                other.sequenceNumber == sequenceNumber) &&
+            (identical(other.scheduledDate, scheduledDate) ||
+                other.scheduledDate == scheduledDate) &&
+            (identical(other.amountMinor, amountMinor) ||
+                other.amountMinor == amountMinor) &&
+            (identical(other.status, status) || other.status == status) &&
+            (identical(other.childTransactionId, childTransactionId) ||
+                other.childTransactionId == childTransactionId) &&
+            (identical(other.createdAt, createdAt) ||
+                other.createdAt == createdAt) &&
+            (identical(other.updatedAt, updatedAt) ||
+                other.updatedAt == updatedAt));
+  }
+
+  @override
+  int get hashCode => Object.hash(
+      runtimeType,
+      id,
+      templateId,
+      sequenceNumber,
+      scheduledDate,
+      amountMinor,
+      status,
+      childTransactionId,
+      createdAt,
+      updatedAt);
+
+  @override
+  String toString() {
+    return 'InstallmentOccurrence(id: $id, templateId: $templateId, sequenceNumber: $sequenceNumber, scheduledDate: $scheduledDate, amountMinor: $amountMinor, status: $status, childTransactionId: $childTransactionId, createdAt: $createdAt, updatedAt: $updatedAt)';
+  }
+}
+
+/// @nodoc
+abstract mixin class _$InstallmentOccurrenceCopyWith<$Res>
+    implements $InstallmentOccurrenceCopyWith<$Res> {
+  factory _$InstallmentOccurrenceCopyWith(_InstallmentOccurrence value,
+          $Res Function(_InstallmentOccurrence) _then) =
+      __$InstallmentOccurrenceCopyWithImpl;
+  @override
+  @useResult
+  $Res call(
+      {String id,
+      String templateId,
+      int sequenceNumber,
+      int scheduledDate,
+      int amountMinor,
+      InstallmentOccurrenceStatus status,
+      String? childTransactionId,
+      int createdAt,
+      int updatedAt});
+}
+
+/// @nodoc
+class __$InstallmentOccurrenceCopyWithImpl<$Res>
+    implements _$InstallmentOccurrenceCopyWith<$Res> {
+  __$InstallmentOccurrenceCopyWithImpl(this._self, this._then);
+
+  final _InstallmentOccurrence _self;
+  final $Res Function(_InstallmentOccurrence) _then;
+
+  /// Create a copy of InstallmentOccurrence
+  /// with the given fields replaced by the non-null parameter values.
+  @override
+  @pragma('vm:prefer-inline')
+  $Res call({
+    Object? id = null,
+    Object? templateId = null,
+    Object? sequenceNumber = null,
+    Object? scheduledDate = null,
+    Object? amountMinor = null,
+    Object? status = null,
+    Object? childTransactionId = freezed,
+    Object? createdAt = null,
+    Object? updatedAt = null,
+  }) {
+    return _then(_InstallmentOccurrence(
+      id: null == id
+          ? _self.id
+          : id // ignore: cast_nullable_to_non_nullable
+              as String,
+      templateId: null == templateId
+          ? _self.templateId
+          : templateId // ignore: cast_nullable_to_non_nullable
+              as String,
+      sequenceNumber: null == sequenceNumber
+          ? _self.sequenceNumber
+          : sequenceNumber // ignore: cast_nullable_to_non_nullable
+              as int,
+      scheduledDate: null == scheduledDate
+          ? _self.scheduledDate
+          : scheduledDate // ignore: cast_nullable_to_non_nullable
+              as int,
+      amountMinor: null == amountMinor
+          ? _self.amountMinor
+          : amountMinor // ignore: cast_nullable_to_non_nullable
+              as int,
+      status: null == status
+          ? _self.status
+          : status // ignore: cast_nullable_to_non_nullable
+              as InstallmentOccurrenceStatus,
+      childTransactionId: freezed == childTransactionId
+          ? _self.childTransactionId
+          : childTransactionId // ignore: cast_nullable_to_non_nullable
+              as String?,
+      createdAt: null == createdAt
+          ? _self.createdAt
+          : createdAt // ignore: cast_nullable_to_non_nullable
+              as int,
+      updatedAt: null == updatedAt
+          ? _self.updatedAt
+          : updatedAt // ignore: cast_nullable_to_non_nullable
+              as int,
+    ));
+  }
+}
+
+// dart format on

--- a/lib/domain/entities/installment_plan.dart
+++ b/lib/domain/entities/installment_plan.dart
@@ -1,0 +1,33 @@
+// lib/domain/entities/installment_plan.dart
+//
+// InstallmentPlan domain entity.
+//
+// Installment-specific metadata for a RecurringTemplate flagged
+// isInstallment = true. One-to-one with the parent recurring_templates row.
+//
+// Computed fields (never stored, always derived from installment_occurrences):
+//   runningTotal       = SUM(amountMinor) WHERE status='posted'
+//   totalRemaining     = SUM(amountMinor) WHERE status='pending'
+//   projectedFinalTotal = runningTotal + totalRemaining
+
+import 'package:freezed_annotation/freezed_annotation.dart';
+
+part 'installment_plan.freezed.dart';
+
+/// Immutable domain entity for installment-specific plan metadata.
+@freezed
+abstract class InstallmentPlan with _$InstallmentPlan {
+  const factory InstallmentPlan({
+    /// UUID v4; also the FK to recurring_templates (same value as templateId).
+    required String templateId,
+
+    /// Target total amount in minor units; immutable except on early close.
+    required int totalConfiguredMinor,
+
+    /// Total number of planned installments; editable for future installments.
+    required int numberOfInstallments,
+
+    /// Creation epoch (Unix seconds).
+    required int createdAt,
+  }) = _InstallmentPlan;
+}

--- a/lib/domain/entities/installment_plan.freezed.dart
+++ b/lib/domain/entities/installment_plan.freezed.dart
@@ -1,0 +1,392 @@
+// GENERATED CODE - DO NOT MODIFY BY HAND
+// coverage:ignore-file
+// ignore_for_file: type=lint
+// ignore_for_file: unused_element, deprecated_member_use, deprecated_member_use_from_same_package, use_function_type_syntax_for_parameters, unnecessary_const, avoid_init_to_null, invalid_override_different_default_values_named, prefer_expression_function_bodies, annotate_overrides, invalid_annotation_target, unnecessary_question_mark
+
+part of 'installment_plan.dart';
+
+// **************************************************************************
+// FreezedGenerator
+// **************************************************************************
+
+// dart format off
+T _$identity<T>(T value) => value;
+
+/// @nodoc
+mixin _$InstallmentPlan {
+  /// UUID v4; also the FK to recurring_templates (same value as templateId).
+  String get templateId;
+
+  /// Target total amount in minor units; immutable except on early close.
+  int get totalConfiguredMinor;
+
+  /// Total number of planned installments; editable for future installments.
+  int get numberOfInstallments;
+
+  /// Creation epoch (Unix seconds).
+  int get createdAt;
+
+  /// Create a copy of InstallmentPlan
+  /// with the given fields replaced by the non-null parameter values.
+  @JsonKey(includeFromJson: false, includeToJson: false)
+  @pragma('vm:prefer-inline')
+  $InstallmentPlanCopyWith<InstallmentPlan> get copyWith =>
+      _$InstallmentPlanCopyWithImpl<InstallmentPlan>(
+          this as InstallmentPlan, _$identity);
+
+  @override
+  bool operator ==(Object other) {
+    return identical(this, other) ||
+        (other.runtimeType == runtimeType &&
+            other is InstallmentPlan &&
+            (identical(other.templateId, templateId) ||
+                other.templateId == templateId) &&
+            (identical(other.totalConfiguredMinor, totalConfiguredMinor) ||
+                other.totalConfiguredMinor == totalConfiguredMinor) &&
+            (identical(other.numberOfInstallments, numberOfInstallments) ||
+                other.numberOfInstallments == numberOfInstallments) &&
+            (identical(other.createdAt, createdAt) ||
+                other.createdAt == createdAt));
+  }
+
+  @override
+  int get hashCode => Object.hash(runtimeType, templateId, totalConfiguredMinor,
+      numberOfInstallments, createdAt);
+
+  @override
+  String toString() {
+    return 'InstallmentPlan(templateId: $templateId, totalConfiguredMinor: $totalConfiguredMinor, numberOfInstallments: $numberOfInstallments, createdAt: $createdAt)';
+  }
+}
+
+/// @nodoc
+abstract mixin class $InstallmentPlanCopyWith<$Res> {
+  factory $InstallmentPlanCopyWith(
+          InstallmentPlan value, $Res Function(InstallmentPlan) _then) =
+      _$InstallmentPlanCopyWithImpl;
+  @useResult
+  $Res call(
+      {String templateId,
+      int totalConfiguredMinor,
+      int numberOfInstallments,
+      int createdAt});
+}
+
+/// @nodoc
+class _$InstallmentPlanCopyWithImpl<$Res>
+    implements $InstallmentPlanCopyWith<$Res> {
+  _$InstallmentPlanCopyWithImpl(this._self, this._then);
+
+  final InstallmentPlan _self;
+  final $Res Function(InstallmentPlan) _then;
+
+  /// Create a copy of InstallmentPlan
+  /// with the given fields replaced by the non-null parameter values.
+  @pragma('vm:prefer-inline')
+  @override
+  $Res call({
+    Object? templateId = null,
+    Object? totalConfiguredMinor = null,
+    Object? numberOfInstallments = null,
+    Object? createdAt = null,
+  }) {
+    return _then(_self.copyWith(
+      templateId: null == templateId
+          ? _self.templateId
+          : templateId // ignore: cast_nullable_to_non_nullable
+              as String,
+      totalConfiguredMinor: null == totalConfiguredMinor
+          ? _self.totalConfiguredMinor
+          : totalConfiguredMinor // ignore: cast_nullable_to_non_nullable
+              as int,
+      numberOfInstallments: null == numberOfInstallments
+          ? _self.numberOfInstallments
+          : numberOfInstallments // ignore: cast_nullable_to_non_nullable
+              as int,
+      createdAt: null == createdAt
+          ? _self.createdAt
+          : createdAt // ignore: cast_nullable_to_non_nullable
+              as int,
+    ));
+  }
+}
+
+/// Adds pattern-matching-related methods to [InstallmentPlan].
+extension InstallmentPlanPatterns on InstallmentPlan {
+  /// A variant of `map` that fallback to returning `orElse`.
+  ///
+  /// It is equivalent to doing:
+  /// ```dart
+  /// switch (sealedClass) {
+  ///   case final Subclass value:
+  ///     return ...;
+  ///   case _:
+  ///     return orElse();
+  /// }
+  /// ```
+
+  @optionalTypeArgs
+  TResult maybeMap<TResult extends Object?>(
+    TResult Function(_InstallmentPlan value)? $default, {
+    required TResult orElse(),
+  }) {
+    final _that = this;
+    switch (_that) {
+      case _InstallmentPlan() when $default != null:
+        return $default(_that);
+      case _:
+        return orElse();
+    }
+  }
+
+  /// A `switch`-like method, using callbacks.
+  ///
+  /// Callbacks receives the raw object, upcasted.
+  /// It is equivalent to doing:
+  /// ```dart
+  /// switch (sealedClass) {
+  ///   case final Subclass value:
+  ///     return ...;
+  ///   case final Subclass2 value:
+  ///     return ...;
+  /// }
+  /// ```
+
+  @optionalTypeArgs
+  TResult map<TResult extends Object?>(
+    TResult Function(_InstallmentPlan value) $default,
+  ) {
+    final _that = this;
+    switch (_that) {
+      case _InstallmentPlan():
+        return $default(_that);
+      case _:
+        throw StateError('Unexpected subclass');
+    }
+  }
+
+  /// A variant of `map` that fallback to returning `null`.
+  ///
+  /// It is equivalent to doing:
+  /// ```dart
+  /// switch (sealedClass) {
+  ///   case final Subclass value:
+  ///     return ...;
+  ///   case _:
+  ///     return null;
+  /// }
+  /// ```
+
+  @optionalTypeArgs
+  TResult? mapOrNull<TResult extends Object?>(
+    TResult? Function(_InstallmentPlan value)? $default,
+  ) {
+    final _that = this;
+    switch (_that) {
+      case _InstallmentPlan() when $default != null:
+        return $default(_that);
+      case _:
+        return null;
+    }
+  }
+
+  /// A variant of `when` that fallback to an `orElse` callback.
+  ///
+  /// It is equivalent to doing:
+  /// ```dart
+  /// switch (sealedClass) {
+  ///   case Subclass(:final field):
+  ///     return ...;
+  ///   case _:
+  ///     return orElse();
+  /// }
+  /// ```
+
+  @optionalTypeArgs
+  TResult maybeWhen<TResult extends Object?>(
+    TResult Function(String templateId, int totalConfiguredMinor,
+            int numberOfInstallments, int createdAt)?
+        $default, {
+    required TResult orElse(),
+  }) {
+    final _that = this;
+    switch (_that) {
+      case _InstallmentPlan() when $default != null:
+        return $default(_that.templateId, _that.totalConfiguredMinor,
+            _that.numberOfInstallments, _that.createdAt);
+      case _:
+        return orElse();
+    }
+  }
+
+  /// A `switch`-like method, using callbacks.
+  ///
+  /// As opposed to `map`, this offers destructuring.
+  /// It is equivalent to doing:
+  /// ```dart
+  /// switch (sealedClass) {
+  ///   case Subclass(:final field):
+  ///     return ...;
+  ///   case Subclass2(:final field2):
+  ///     return ...;
+  /// }
+  /// ```
+
+  @optionalTypeArgs
+  TResult when<TResult extends Object?>(
+    TResult Function(String templateId, int totalConfiguredMinor,
+            int numberOfInstallments, int createdAt)
+        $default,
+  ) {
+    final _that = this;
+    switch (_that) {
+      case _InstallmentPlan():
+        return $default(_that.templateId, _that.totalConfiguredMinor,
+            _that.numberOfInstallments, _that.createdAt);
+      case _:
+        throw StateError('Unexpected subclass');
+    }
+  }
+
+  /// A variant of `when` that fallback to returning `null`
+  ///
+  /// It is equivalent to doing:
+  /// ```dart
+  /// switch (sealedClass) {
+  ///   case Subclass(:final field):
+  ///     return ...;
+  ///   case _:
+  ///     return null;
+  /// }
+  /// ```
+
+  @optionalTypeArgs
+  TResult? whenOrNull<TResult extends Object?>(
+    TResult? Function(String templateId, int totalConfiguredMinor,
+            int numberOfInstallments, int createdAt)?
+        $default,
+  ) {
+    final _that = this;
+    switch (_that) {
+      case _InstallmentPlan() when $default != null:
+        return $default(_that.templateId, _that.totalConfiguredMinor,
+            _that.numberOfInstallments, _that.createdAt);
+      case _:
+        return null;
+    }
+  }
+}
+
+/// @nodoc
+
+class _InstallmentPlan implements InstallmentPlan {
+  const _InstallmentPlan(
+      {required this.templateId,
+      required this.totalConfiguredMinor,
+      required this.numberOfInstallments,
+      required this.createdAt});
+
+  /// UUID v4; also the FK to recurring_templates (same value as templateId).
+  @override
+  final String templateId;
+
+  /// Target total amount in minor units; immutable except on early close.
+  @override
+  final int totalConfiguredMinor;
+
+  /// Total number of planned installments; editable for future installments.
+  @override
+  final int numberOfInstallments;
+
+  /// Creation epoch (Unix seconds).
+  @override
+  final int createdAt;
+
+  /// Create a copy of InstallmentPlan
+  /// with the given fields replaced by the non-null parameter values.
+  @override
+  @JsonKey(includeFromJson: false, includeToJson: false)
+  @pragma('vm:prefer-inline')
+  _$InstallmentPlanCopyWith<_InstallmentPlan> get copyWith =>
+      __$InstallmentPlanCopyWithImpl<_InstallmentPlan>(this, _$identity);
+
+  @override
+  bool operator ==(Object other) {
+    return identical(this, other) ||
+        (other.runtimeType == runtimeType &&
+            other is _InstallmentPlan &&
+            (identical(other.templateId, templateId) ||
+                other.templateId == templateId) &&
+            (identical(other.totalConfiguredMinor, totalConfiguredMinor) ||
+                other.totalConfiguredMinor == totalConfiguredMinor) &&
+            (identical(other.numberOfInstallments, numberOfInstallments) ||
+                other.numberOfInstallments == numberOfInstallments) &&
+            (identical(other.createdAt, createdAt) ||
+                other.createdAt == createdAt));
+  }
+
+  @override
+  int get hashCode => Object.hash(runtimeType, templateId, totalConfiguredMinor,
+      numberOfInstallments, createdAt);
+
+  @override
+  String toString() {
+    return 'InstallmentPlan(templateId: $templateId, totalConfiguredMinor: $totalConfiguredMinor, numberOfInstallments: $numberOfInstallments, createdAt: $createdAt)';
+  }
+}
+
+/// @nodoc
+abstract mixin class _$InstallmentPlanCopyWith<$Res>
+    implements $InstallmentPlanCopyWith<$Res> {
+  factory _$InstallmentPlanCopyWith(
+          _InstallmentPlan value, $Res Function(_InstallmentPlan) _then) =
+      __$InstallmentPlanCopyWithImpl;
+  @override
+  @useResult
+  $Res call(
+      {String templateId,
+      int totalConfiguredMinor,
+      int numberOfInstallments,
+      int createdAt});
+}
+
+/// @nodoc
+class __$InstallmentPlanCopyWithImpl<$Res>
+    implements _$InstallmentPlanCopyWith<$Res> {
+  __$InstallmentPlanCopyWithImpl(this._self, this._then);
+
+  final _InstallmentPlan _self;
+  final $Res Function(_InstallmentPlan) _then;
+
+  /// Create a copy of InstallmentPlan
+  /// with the given fields replaced by the non-null parameter values.
+  @override
+  @pragma('vm:prefer-inline')
+  $Res call({
+    Object? templateId = null,
+    Object? totalConfiguredMinor = null,
+    Object? numberOfInstallments = null,
+    Object? createdAt = null,
+  }) {
+    return _then(_InstallmentPlan(
+      templateId: null == templateId
+          ? _self.templateId
+          : templateId // ignore: cast_nullable_to_non_nullable
+              as String,
+      totalConfiguredMinor: null == totalConfiguredMinor
+          ? _self.totalConfiguredMinor
+          : totalConfiguredMinor // ignore: cast_nullable_to_non_nullable
+              as int,
+      numberOfInstallments: null == numberOfInstallments
+          ? _self.numberOfInstallments
+          : numberOfInstallments // ignore: cast_nullable_to_non_nullable
+              as int,
+      createdAt: null == createdAt
+          ? _self.createdAt
+          : createdAt // ignore: cast_nullable_to_non_nullable
+              as int,
+    ));
+  }
+}
+
+// dart format on

--- a/lib/domain/entities/money.dart
+++ b/lib/domain/entities/money.dart
@@ -1,0 +1,30 @@
+// lib/domain/entities/money.dart
+//
+// Money value object: amount in minor units + ISO 4217 currency code.
+//
+// All monetary amounts in the domain are represented as integer minor units
+// (the smallest denomination of a currency). Never use double for money.
+//
+// Examples:
+//   Money(amountMinor: 50000, currencyCode: 'USD') → $500.00
+//   Money(amountMinor: 500, currencyCode: 'JPY')   → ¥500
+//   Money(amountMinor: 500000, currencyCode: 'BHD') → BHD 500.000
+
+import 'package:freezed_annotation/freezed_annotation.dart';
+
+part 'money.freezed.dart';
+
+/// Immutable value object representing a monetary amount.
+///
+/// [amountMinor] is always a non-negative integer in the currency's minor
+/// unit (e.g. cents for USD, paise for INR, yen for JPY).
+@freezed
+abstract class Money with _$Money {
+  const factory Money({
+    /// Amount in the smallest denomination of [currencyCode].
+    required int amountMinor,
+
+    /// ISO 4217 three-letter currency code (e.g. 'USD', 'INR', 'JPY').
+    required String currencyCode,
+  }) = _Money;
+}

--- a/lib/domain/entities/money.freezed.dart
+++ b/lib/domain/entities/money.freezed.dart
@@ -1,0 +1,321 @@
+// GENERATED CODE - DO NOT MODIFY BY HAND
+// coverage:ignore-file
+// ignore_for_file: type=lint
+// ignore_for_file: unused_element, deprecated_member_use, deprecated_member_use_from_same_package, use_function_type_syntax_for_parameters, unnecessary_const, avoid_init_to_null, invalid_override_different_default_values_named, prefer_expression_function_bodies, annotate_overrides, invalid_annotation_target, unnecessary_question_mark
+
+part of 'money.dart';
+
+// **************************************************************************
+// FreezedGenerator
+// **************************************************************************
+
+// dart format off
+T _$identity<T>(T value) => value;
+
+/// @nodoc
+mixin _$Money {
+  /// Amount in the smallest denomination of [currencyCode].
+  int get amountMinor;
+
+  /// ISO 4217 three-letter currency code (e.g. 'USD', 'INR', 'JPY').
+  String get currencyCode;
+
+  /// Create a copy of Money
+  /// with the given fields replaced by the non-null parameter values.
+  @JsonKey(includeFromJson: false, includeToJson: false)
+  @pragma('vm:prefer-inline')
+  $MoneyCopyWith<Money> get copyWith =>
+      _$MoneyCopyWithImpl<Money>(this as Money, _$identity);
+
+  @override
+  bool operator ==(Object other) {
+    return identical(this, other) ||
+        (other.runtimeType == runtimeType &&
+            other is Money &&
+            (identical(other.amountMinor, amountMinor) ||
+                other.amountMinor == amountMinor) &&
+            (identical(other.currencyCode, currencyCode) ||
+                other.currencyCode == currencyCode));
+  }
+
+  @override
+  int get hashCode => Object.hash(runtimeType, amountMinor, currencyCode);
+
+  @override
+  String toString() {
+    return 'Money(amountMinor: $amountMinor, currencyCode: $currencyCode)';
+  }
+}
+
+/// @nodoc
+abstract mixin class $MoneyCopyWith<$Res> {
+  factory $MoneyCopyWith(Money value, $Res Function(Money) _then) =
+      _$MoneyCopyWithImpl;
+  @useResult
+  $Res call({int amountMinor, String currencyCode});
+}
+
+/// @nodoc
+class _$MoneyCopyWithImpl<$Res> implements $MoneyCopyWith<$Res> {
+  _$MoneyCopyWithImpl(this._self, this._then);
+
+  final Money _self;
+  final $Res Function(Money) _then;
+
+  /// Create a copy of Money
+  /// with the given fields replaced by the non-null parameter values.
+  @pragma('vm:prefer-inline')
+  @override
+  $Res call({
+    Object? amountMinor = null,
+    Object? currencyCode = null,
+  }) {
+    return _then(_self.copyWith(
+      amountMinor: null == amountMinor
+          ? _self.amountMinor
+          : amountMinor // ignore: cast_nullable_to_non_nullable
+              as int,
+      currencyCode: null == currencyCode
+          ? _self.currencyCode
+          : currencyCode // ignore: cast_nullable_to_non_nullable
+              as String,
+    ));
+  }
+}
+
+/// Adds pattern-matching-related methods to [Money].
+extension MoneyPatterns on Money {
+  /// A variant of `map` that fallback to returning `orElse`.
+  ///
+  /// It is equivalent to doing:
+  /// ```dart
+  /// switch (sealedClass) {
+  ///   case final Subclass value:
+  ///     return ...;
+  ///   case _:
+  ///     return orElse();
+  /// }
+  /// ```
+
+  @optionalTypeArgs
+  TResult maybeMap<TResult extends Object?>(
+    TResult Function(_Money value)? $default, {
+    required TResult orElse(),
+  }) {
+    final _that = this;
+    switch (_that) {
+      case _Money() when $default != null:
+        return $default(_that);
+      case _:
+        return orElse();
+    }
+  }
+
+  /// A `switch`-like method, using callbacks.
+  ///
+  /// Callbacks receives the raw object, upcasted.
+  /// It is equivalent to doing:
+  /// ```dart
+  /// switch (sealedClass) {
+  ///   case final Subclass value:
+  ///     return ...;
+  ///   case final Subclass2 value:
+  ///     return ...;
+  /// }
+  /// ```
+
+  @optionalTypeArgs
+  TResult map<TResult extends Object?>(
+    TResult Function(_Money value) $default,
+  ) {
+    final _that = this;
+    switch (_that) {
+      case _Money():
+        return $default(_that);
+      case _:
+        throw StateError('Unexpected subclass');
+    }
+  }
+
+  /// A variant of `map` that fallback to returning `null`.
+  ///
+  /// It is equivalent to doing:
+  /// ```dart
+  /// switch (sealedClass) {
+  ///   case final Subclass value:
+  ///     return ...;
+  ///   case _:
+  ///     return null;
+  /// }
+  /// ```
+
+  @optionalTypeArgs
+  TResult? mapOrNull<TResult extends Object?>(
+    TResult? Function(_Money value)? $default,
+  ) {
+    final _that = this;
+    switch (_that) {
+      case _Money() when $default != null:
+        return $default(_that);
+      case _:
+        return null;
+    }
+  }
+
+  /// A variant of `when` that fallback to an `orElse` callback.
+  ///
+  /// It is equivalent to doing:
+  /// ```dart
+  /// switch (sealedClass) {
+  ///   case Subclass(:final field):
+  ///     return ...;
+  ///   case _:
+  ///     return orElse();
+  /// }
+  /// ```
+
+  @optionalTypeArgs
+  TResult maybeWhen<TResult extends Object?>(
+    TResult Function(int amountMinor, String currencyCode)? $default, {
+    required TResult orElse(),
+  }) {
+    final _that = this;
+    switch (_that) {
+      case _Money() when $default != null:
+        return $default(_that.amountMinor, _that.currencyCode);
+      case _:
+        return orElse();
+    }
+  }
+
+  /// A `switch`-like method, using callbacks.
+  ///
+  /// As opposed to `map`, this offers destructuring.
+  /// It is equivalent to doing:
+  /// ```dart
+  /// switch (sealedClass) {
+  ///   case Subclass(:final field):
+  ///     return ...;
+  ///   case Subclass2(:final field2):
+  ///     return ...;
+  /// }
+  /// ```
+
+  @optionalTypeArgs
+  TResult when<TResult extends Object?>(
+    TResult Function(int amountMinor, String currencyCode) $default,
+  ) {
+    final _that = this;
+    switch (_that) {
+      case _Money():
+        return $default(_that.amountMinor, _that.currencyCode);
+      case _:
+        throw StateError('Unexpected subclass');
+    }
+  }
+
+  /// A variant of `when` that fallback to returning `null`
+  ///
+  /// It is equivalent to doing:
+  /// ```dart
+  /// switch (sealedClass) {
+  ///   case Subclass(:final field):
+  ///     return ...;
+  ///   case _:
+  ///     return null;
+  /// }
+  /// ```
+
+  @optionalTypeArgs
+  TResult? whenOrNull<TResult extends Object?>(
+    TResult? Function(int amountMinor, String currencyCode)? $default,
+  ) {
+    final _that = this;
+    switch (_that) {
+      case _Money() when $default != null:
+        return $default(_that.amountMinor, _that.currencyCode);
+      case _:
+        return null;
+    }
+  }
+}
+
+/// @nodoc
+
+class _Money implements Money {
+  const _Money({required this.amountMinor, required this.currencyCode});
+
+  /// Amount in the smallest denomination of [currencyCode].
+  @override
+  final int amountMinor;
+
+  /// ISO 4217 three-letter currency code (e.g. 'USD', 'INR', 'JPY').
+  @override
+  final String currencyCode;
+
+  /// Create a copy of Money
+  /// with the given fields replaced by the non-null parameter values.
+  @override
+  @JsonKey(includeFromJson: false, includeToJson: false)
+  @pragma('vm:prefer-inline')
+  _$MoneyCopyWith<_Money> get copyWith =>
+      __$MoneyCopyWithImpl<_Money>(this, _$identity);
+
+  @override
+  bool operator ==(Object other) {
+    return identical(this, other) ||
+        (other.runtimeType == runtimeType &&
+            other is _Money &&
+            (identical(other.amountMinor, amountMinor) ||
+                other.amountMinor == amountMinor) &&
+            (identical(other.currencyCode, currencyCode) ||
+                other.currencyCode == currencyCode));
+  }
+
+  @override
+  int get hashCode => Object.hash(runtimeType, amountMinor, currencyCode);
+
+  @override
+  String toString() {
+    return 'Money(amountMinor: $amountMinor, currencyCode: $currencyCode)';
+  }
+}
+
+/// @nodoc
+abstract mixin class _$MoneyCopyWith<$Res> implements $MoneyCopyWith<$Res> {
+  factory _$MoneyCopyWith(_Money value, $Res Function(_Money) _then) =
+      __$MoneyCopyWithImpl;
+  @override
+  @useResult
+  $Res call({int amountMinor, String currencyCode});
+}
+
+/// @nodoc
+class __$MoneyCopyWithImpl<$Res> implements _$MoneyCopyWith<$Res> {
+  __$MoneyCopyWithImpl(this._self, this._then);
+
+  final _Money _self;
+  final $Res Function(_Money) _then;
+
+  /// Create a copy of Money
+  /// with the given fields replaced by the non-null parameter values.
+  @override
+  @pragma('vm:prefer-inline')
+  $Res call({
+    Object? amountMinor = null,
+    Object? currencyCode = null,
+  }) {
+    return _then(_Money(
+      amountMinor: null == amountMinor
+          ? _self.amountMinor
+          : amountMinor // ignore: cast_nullable_to_non_nullable
+              as int,
+      currencyCode: null == currencyCode
+          ? _self.currencyCode
+          : currencyCode // ignore: cast_nullable_to_non_nullable
+              as String,
+    ));
+  }
+}
+
+// dart format on

--- a/lib/domain/entities/payee.dart
+++ b/lib/domain/entities/payee.dart
@@ -1,0 +1,34 @@
+// lib/domain/entities/payee.dart
+//
+// Payee domain entity.
+//
+// Optional named payees/merchants attached to transactions.
+// Schema-ready in v1; the payee management screen is v2.
+
+import 'package:freezed_annotation/freezed_annotation.dart';
+
+part 'payee.freezed.dart';
+
+/// Immutable domain entity for a payee or merchant.
+@freezed
+abstract class Payee with _$Payee {
+  const factory Payee({
+    /// UUID v4 stable identifier.
+    required String id,
+
+    /// Payee name; unique (case-insensitive enforced at app layer).
+    required String name,
+
+    /// Soft-delete flag.
+    @Default(false) bool isDeleted,
+
+    /// Soft-delete epoch (Unix seconds).
+    int? deletedAt,
+
+    /// Creation epoch (Unix seconds).
+    required int createdAt,
+
+    /// Last-modified epoch (Unix seconds).
+    required int updatedAt,
+  }) = _Payee;
+}

--- a/lib/domain/entities/payee.freezed.dart
+++ b/lib/domain/entities/payee.freezed.dart
@@ -1,0 +1,431 @@
+// GENERATED CODE - DO NOT MODIFY BY HAND
+// coverage:ignore-file
+// ignore_for_file: type=lint
+// ignore_for_file: unused_element, deprecated_member_use, deprecated_member_use_from_same_package, use_function_type_syntax_for_parameters, unnecessary_const, avoid_init_to_null, invalid_override_different_default_values_named, prefer_expression_function_bodies, annotate_overrides, invalid_annotation_target, unnecessary_question_mark
+
+part of 'payee.dart';
+
+// **************************************************************************
+// FreezedGenerator
+// **************************************************************************
+
+// dart format off
+T _$identity<T>(T value) => value;
+
+/// @nodoc
+mixin _$Payee {
+  /// UUID v4 stable identifier.
+  String get id;
+
+  /// Payee name; unique (case-insensitive enforced at app layer).
+  String get name;
+
+  /// Soft-delete flag.
+  bool get isDeleted;
+
+  /// Soft-delete epoch (Unix seconds).
+  int? get deletedAt;
+
+  /// Creation epoch (Unix seconds).
+  int get createdAt;
+
+  /// Last-modified epoch (Unix seconds).
+  int get updatedAt;
+
+  /// Create a copy of Payee
+  /// with the given fields replaced by the non-null parameter values.
+  @JsonKey(includeFromJson: false, includeToJson: false)
+  @pragma('vm:prefer-inline')
+  $PayeeCopyWith<Payee> get copyWith =>
+      _$PayeeCopyWithImpl<Payee>(this as Payee, _$identity);
+
+  @override
+  bool operator ==(Object other) {
+    return identical(this, other) ||
+        (other.runtimeType == runtimeType &&
+            other is Payee &&
+            (identical(other.id, id) || other.id == id) &&
+            (identical(other.name, name) || other.name == name) &&
+            (identical(other.isDeleted, isDeleted) ||
+                other.isDeleted == isDeleted) &&
+            (identical(other.deletedAt, deletedAt) ||
+                other.deletedAt == deletedAt) &&
+            (identical(other.createdAt, createdAt) ||
+                other.createdAt == createdAt) &&
+            (identical(other.updatedAt, updatedAt) ||
+                other.updatedAt == updatedAt));
+  }
+
+  @override
+  int get hashCode => Object.hash(
+      runtimeType, id, name, isDeleted, deletedAt, createdAt, updatedAt);
+
+  @override
+  String toString() {
+    return 'Payee(id: $id, name: $name, isDeleted: $isDeleted, deletedAt: $deletedAt, createdAt: $createdAt, updatedAt: $updatedAt)';
+  }
+}
+
+/// @nodoc
+abstract mixin class $PayeeCopyWith<$Res> {
+  factory $PayeeCopyWith(Payee value, $Res Function(Payee) _then) =
+      _$PayeeCopyWithImpl;
+  @useResult
+  $Res call(
+      {String id,
+      String name,
+      bool isDeleted,
+      int? deletedAt,
+      int createdAt,
+      int updatedAt});
+}
+
+/// @nodoc
+class _$PayeeCopyWithImpl<$Res> implements $PayeeCopyWith<$Res> {
+  _$PayeeCopyWithImpl(this._self, this._then);
+
+  final Payee _self;
+  final $Res Function(Payee) _then;
+
+  /// Create a copy of Payee
+  /// with the given fields replaced by the non-null parameter values.
+  @pragma('vm:prefer-inline')
+  @override
+  $Res call({
+    Object? id = null,
+    Object? name = null,
+    Object? isDeleted = null,
+    Object? deletedAt = freezed,
+    Object? createdAt = null,
+    Object? updatedAt = null,
+  }) {
+    return _then(_self.copyWith(
+      id: null == id
+          ? _self.id
+          : id // ignore: cast_nullable_to_non_nullable
+              as String,
+      name: null == name
+          ? _self.name
+          : name // ignore: cast_nullable_to_non_nullable
+              as String,
+      isDeleted: null == isDeleted
+          ? _self.isDeleted
+          : isDeleted // ignore: cast_nullable_to_non_nullable
+              as bool,
+      deletedAt: freezed == deletedAt
+          ? _self.deletedAt
+          : deletedAt // ignore: cast_nullable_to_non_nullable
+              as int?,
+      createdAt: null == createdAt
+          ? _self.createdAt
+          : createdAt // ignore: cast_nullable_to_non_nullable
+              as int,
+      updatedAt: null == updatedAt
+          ? _self.updatedAt
+          : updatedAt // ignore: cast_nullable_to_non_nullable
+              as int,
+    ));
+  }
+}
+
+/// Adds pattern-matching-related methods to [Payee].
+extension PayeePatterns on Payee {
+  /// A variant of `map` that fallback to returning `orElse`.
+  ///
+  /// It is equivalent to doing:
+  /// ```dart
+  /// switch (sealedClass) {
+  ///   case final Subclass value:
+  ///     return ...;
+  ///   case _:
+  ///     return orElse();
+  /// }
+  /// ```
+
+  @optionalTypeArgs
+  TResult maybeMap<TResult extends Object?>(
+    TResult Function(_Payee value)? $default, {
+    required TResult orElse(),
+  }) {
+    final _that = this;
+    switch (_that) {
+      case _Payee() when $default != null:
+        return $default(_that);
+      case _:
+        return orElse();
+    }
+  }
+
+  /// A `switch`-like method, using callbacks.
+  ///
+  /// Callbacks receives the raw object, upcasted.
+  /// It is equivalent to doing:
+  /// ```dart
+  /// switch (sealedClass) {
+  ///   case final Subclass value:
+  ///     return ...;
+  ///   case final Subclass2 value:
+  ///     return ...;
+  /// }
+  /// ```
+
+  @optionalTypeArgs
+  TResult map<TResult extends Object?>(
+    TResult Function(_Payee value) $default,
+  ) {
+    final _that = this;
+    switch (_that) {
+      case _Payee():
+        return $default(_that);
+      case _:
+        throw StateError('Unexpected subclass');
+    }
+  }
+
+  /// A variant of `map` that fallback to returning `null`.
+  ///
+  /// It is equivalent to doing:
+  /// ```dart
+  /// switch (sealedClass) {
+  ///   case final Subclass value:
+  ///     return ...;
+  ///   case _:
+  ///     return null;
+  /// }
+  /// ```
+
+  @optionalTypeArgs
+  TResult? mapOrNull<TResult extends Object?>(
+    TResult? Function(_Payee value)? $default,
+  ) {
+    final _that = this;
+    switch (_that) {
+      case _Payee() when $default != null:
+        return $default(_that);
+      case _:
+        return null;
+    }
+  }
+
+  /// A variant of `when` that fallback to an `orElse` callback.
+  ///
+  /// It is equivalent to doing:
+  /// ```dart
+  /// switch (sealedClass) {
+  ///   case Subclass(:final field):
+  ///     return ...;
+  ///   case _:
+  ///     return orElse();
+  /// }
+  /// ```
+
+  @optionalTypeArgs
+  TResult maybeWhen<TResult extends Object?>(
+    TResult Function(String id, String name, bool isDeleted, int? deletedAt,
+            int createdAt, int updatedAt)?
+        $default, {
+    required TResult orElse(),
+  }) {
+    final _that = this;
+    switch (_that) {
+      case _Payee() when $default != null:
+        return $default(_that.id, _that.name, _that.isDeleted, _that.deletedAt,
+            _that.createdAt, _that.updatedAt);
+      case _:
+        return orElse();
+    }
+  }
+
+  /// A `switch`-like method, using callbacks.
+  ///
+  /// As opposed to `map`, this offers destructuring.
+  /// It is equivalent to doing:
+  /// ```dart
+  /// switch (sealedClass) {
+  ///   case Subclass(:final field):
+  ///     return ...;
+  ///   case Subclass2(:final field2):
+  ///     return ...;
+  /// }
+  /// ```
+
+  @optionalTypeArgs
+  TResult when<TResult extends Object?>(
+    TResult Function(String id, String name, bool isDeleted, int? deletedAt,
+            int createdAt, int updatedAt)
+        $default,
+  ) {
+    final _that = this;
+    switch (_that) {
+      case _Payee():
+        return $default(_that.id, _that.name, _that.isDeleted, _that.deletedAt,
+            _that.createdAt, _that.updatedAt);
+      case _:
+        throw StateError('Unexpected subclass');
+    }
+  }
+
+  /// A variant of `when` that fallback to returning `null`
+  ///
+  /// It is equivalent to doing:
+  /// ```dart
+  /// switch (sealedClass) {
+  ///   case Subclass(:final field):
+  ///     return ...;
+  ///   case _:
+  ///     return null;
+  /// }
+  /// ```
+
+  @optionalTypeArgs
+  TResult? whenOrNull<TResult extends Object?>(
+    TResult? Function(String id, String name, bool isDeleted, int? deletedAt,
+            int createdAt, int updatedAt)?
+        $default,
+  ) {
+    final _that = this;
+    switch (_that) {
+      case _Payee() when $default != null:
+        return $default(_that.id, _that.name, _that.isDeleted, _that.deletedAt,
+            _that.createdAt, _that.updatedAt);
+      case _:
+        return null;
+    }
+  }
+}
+
+/// @nodoc
+
+class _Payee implements Payee {
+  const _Payee(
+      {required this.id,
+      required this.name,
+      this.isDeleted = false,
+      this.deletedAt,
+      required this.createdAt,
+      required this.updatedAt});
+
+  /// UUID v4 stable identifier.
+  @override
+  final String id;
+
+  /// Payee name; unique (case-insensitive enforced at app layer).
+  @override
+  final String name;
+
+  /// Soft-delete flag.
+  @override
+  @JsonKey()
+  final bool isDeleted;
+
+  /// Soft-delete epoch (Unix seconds).
+  @override
+  final int? deletedAt;
+
+  /// Creation epoch (Unix seconds).
+  @override
+  final int createdAt;
+
+  /// Last-modified epoch (Unix seconds).
+  @override
+  final int updatedAt;
+
+  /// Create a copy of Payee
+  /// with the given fields replaced by the non-null parameter values.
+  @override
+  @JsonKey(includeFromJson: false, includeToJson: false)
+  @pragma('vm:prefer-inline')
+  _$PayeeCopyWith<_Payee> get copyWith =>
+      __$PayeeCopyWithImpl<_Payee>(this, _$identity);
+
+  @override
+  bool operator ==(Object other) {
+    return identical(this, other) ||
+        (other.runtimeType == runtimeType &&
+            other is _Payee &&
+            (identical(other.id, id) || other.id == id) &&
+            (identical(other.name, name) || other.name == name) &&
+            (identical(other.isDeleted, isDeleted) ||
+                other.isDeleted == isDeleted) &&
+            (identical(other.deletedAt, deletedAt) ||
+                other.deletedAt == deletedAt) &&
+            (identical(other.createdAt, createdAt) ||
+                other.createdAt == createdAt) &&
+            (identical(other.updatedAt, updatedAt) ||
+                other.updatedAt == updatedAt));
+  }
+
+  @override
+  int get hashCode => Object.hash(
+      runtimeType, id, name, isDeleted, deletedAt, createdAt, updatedAt);
+
+  @override
+  String toString() {
+    return 'Payee(id: $id, name: $name, isDeleted: $isDeleted, deletedAt: $deletedAt, createdAt: $createdAt, updatedAt: $updatedAt)';
+  }
+}
+
+/// @nodoc
+abstract mixin class _$PayeeCopyWith<$Res> implements $PayeeCopyWith<$Res> {
+  factory _$PayeeCopyWith(_Payee value, $Res Function(_Payee) _then) =
+      __$PayeeCopyWithImpl;
+  @override
+  @useResult
+  $Res call(
+      {String id,
+      String name,
+      bool isDeleted,
+      int? deletedAt,
+      int createdAt,
+      int updatedAt});
+}
+
+/// @nodoc
+class __$PayeeCopyWithImpl<$Res> implements _$PayeeCopyWith<$Res> {
+  __$PayeeCopyWithImpl(this._self, this._then);
+
+  final _Payee _self;
+  final $Res Function(_Payee) _then;
+
+  /// Create a copy of Payee
+  /// with the given fields replaced by the non-null parameter values.
+  @override
+  @pragma('vm:prefer-inline')
+  $Res call({
+    Object? id = null,
+    Object? name = null,
+    Object? isDeleted = null,
+    Object? deletedAt = freezed,
+    Object? createdAt = null,
+    Object? updatedAt = null,
+  }) {
+    return _then(_Payee(
+      id: null == id
+          ? _self.id
+          : id // ignore: cast_nullable_to_non_nullable
+              as String,
+      name: null == name
+          ? _self.name
+          : name // ignore: cast_nullable_to_non_nullable
+              as String,
+      isDeleted: null == isDeleted
+          ? _self.isDeleted
+          : isDeleted // ignore: cast_nullable_to_non_nullable
+              as bool,
+      deletedAt: freezed == deletedAt
+          ? _self.deletedAt
+          : deletedAt // ignore: cast_nullable_to_non_nullable
+              as int?,
+      createdAt: null == createdAt
+          ? _self.createdAt
+          : createdAt // ignore: cast_nullable_to_non_nullable
+              as int,
+      updatedAt: null == updatedAt
+          ? _self.updatedAt
+          : updatedAt // ignore: cast_nullable_to_non_nullable
+              as int,
+    ));
+  }
+}
+
+// dart format on

--- a/lib/domain/entities/recurring_template.dart
+++ b/lib/domain/entities/recurring_template.dart
@@ -1,0 +1,166 @@
+// lib/domain/entities/recurring_template.dart
+//
+// RecurringTemplate domain entity.
+//
+// Template definition for recurring and installment transaction series.
+// The isInstallment flag distinguishes the two sub-types; installment-specific
+// metadata lives in InstallmentPlan (1:1 relation).
+//
+// Lifecycle states (TC-043):
+//   active → paused → active (resumable)
+//   active/paused → archived (terminal)
+//   active/paused → deleted (soft-delete, terminal)
+//
+// Immutable after creation: transactionType, recurrenceN, recurrenceUnit,
+// recurrenceConstraints, startDate, endDate (for recurring).
+
+import 'package:freezed_annotation/freezed_annotation.dart';
+
+part 'recurring_template.freezed.dart';
+
+/// Lifecycle state of a recurring template (TC-043).
+enum RecurringTemplateStatus {
+  active,
+  paused,
+  archived,
+  deleted,
+}
+
+/// Time unit for recurrence cadence.
+enum RecurrenceUnit {
+  day,
+  week,
+  month,
+  year,
+}
+
+/// Optional scheduling constraint applied to an occurrence date.
+enum RecurrenceConstraint {
+  weekdaysOnly,
+  weekendsOnly,
+  startOfMonth,
+  endOfMonth,
+  startOfYear,
+  endOfYear,
+}
+
+/// Fee mode for transfer templates that carry a service fee.
+enum FeeMode {
+  flat,
+  percentage,
+}
+
+/// Auto-posting behaviour.
+enum PostingBehaviour {
+  autoPost,
+  remindAndConfirm,
+}
+
+/// Archival trigger reason.
+enum ArchivedReason {
+  endDateReached,
+  installmentsExhausted,
+  earlyClose,
+  userStopped,
+}
+
+/// Immutable domain entity for a recurring or installment template.
+@freezed
+abstract class RecurringTemplate with _$RecurringTemplate {
+  const factory RecurringTemplate({
+    /// UUID v4 stable identifier.
+    required String id,
+
+    /// Financial direction; immutable after creation.
+    required String transactionType,
+
+    /// Lifecycle state.
+    @Default(RecurringTemplateStatus.active) RecurringTemplateStatus status,
+
+    /// Per-occurrence amount in minor units; in-place editable.
+    required int amountMinor,
+
+    /// ISO 4217 code; derived from source account.
+    required String currencyCode,
+
+    /// Source account UUID; null for income.
+    String? accountSourceId,
+
+    /// Destination account UUID; null for expense.
+    String? accountDestinationId,
+
+    /// Category UUID; null for transfer; editable.
+    String? categoryId,
+
+    /// Subcategory UUID; editable.
+    String? subcategoryId,
+
+    /// Payee UUID; optional.
+    String? payeeId,
+
+    /// Template title; editable.
+    String? title,
+
+    /// Description; editable.
+    String? description,
+
+    /// Cadence multiplier (e.g. 2 in "every 2 weeks"); immutable.
+    required int recurrenceN,
+
+    /// Cadence time unit; immutable.
+    required RecurrenceUnit recurrenceUnit,
+
+    /// Optional scheduling constraints (JSON array of [RecurrenceConstraint]);
+    /// immutable.
+    List<RecurrenceConstraint>? recurrenceConstraints,
+
+    /// First occurrence date (Unix epoch days); immutable.
+    required int startDate,
+
+    /// Last valid occurrence date; immutable for recurring; computed for
+    /// installments.
+    int? endDate,
+
+    /// Auto-posting behaviour; editable.
+    @Default(PostingBehaviour.autoPost) PostingBehaviour postingBehaviour,
+
+    /// Transfer fee mode; null = no fee.
+    FeeMode? feeMode,
+
+    /// Flat fee in minor units.
+    int? feeAmountMinor,
+
+    /// Percentage fee × 1,000,000.
+    int? feePercentageMicro,
+
+    /// Fee expense category UUID.
+    String? feeCategoryId,
+
+    /// Resume-after epoch; null = not paused.
+    int? pauseUntil,
+
+    /// Archival epoch; null = not archived.
+    int? archivedAt,
+
+    /// Archival trigger; null = not archived.
+    ArchivedReason? archivedReason,
+
+    /// Discriminator: false = recurring, true = installment.
+    @Default(false) bool isInstallment,
+
+    /// Soft-delete flag.
+    @Default(false) bool isDeleted,
+
+    /// Soft-delete epoch.
+    int? deletedAt,
+
+    /// Creation epoch (Unix seconds).
+    required int createdAt,
+
+    /// Last-modified epoch (Unix seconds).
+    required int updatedAt,
+
+    /// JSON escape hatch.
+    String? metadata,
+  }) = _RecurringTemplate;
+}

--- a/lib/domain/entities/recurring_template.freezed.dart
+++ b/lib/domain/entities/recurring_template.freezed.dart
@@ -1,0 +1,1292 @@
+// GENERATED CODE - DO NOT MODIFY BY HAND
+// coverage:ignore-file
+// ignore_for_file: type=lint
+// ignore_for_file: unused_element, deprecated_member_use, deprecated_member_use_from_same_package, use_function_type_syntax_for_parameters, unnecessary_const, avoid_init_to_null, invalid_override_different_default_values_named, prefer_expression_function_bodies, annotate_overrides, invalid_annotation_target, unnecessary_question_mark
+
+part of 'recurring_template.dart';
+
+// **************************************************************************
+// FreezedGenerator
+// **************************************************************************
+
+// dart format off
+T _$identity<T>(T value) => value;
+
+/// @nodoc
+mixin _$RecurringTemplate {
+  /// UUID v4 stable identifier.
+  String get id;
+
+  /// Financial direction; immutable after creation.
+  String get transactionType;
+
+  /// Lifecycle state.
+  RecurringTemplateStatus get status;
+
+  /// Per-occurrence amount in minor units; in-place editable.
+  int get amountMinor;
+
+  /// ISO 4217 code; derived from source account.
+  String get currencyCode;
+
+  /// Source account UUID; null for income.
+  String? get accountSourceId;
+
+  /// Destination account UUID; null for expense.
+  String? get accountDestinationId;
+
+  /// Category UUID; null for transfer; editable.
+  String? get categoryId;
+
+  /// Subcategory UUID; editable.
+  String? get subcategoryId;
+
+  /// Payee UUID; optional.
+  String? get payeeId;
+
+  /// Template title; editable.
+  String? get title;
+
+  /// Description; editable.
+  String? get description;
+
+  /// Cadence multiplier (e.g. 2 in "every 2 weeks"); immutable.
+  int get recurrenceN;
+
+  /// Cadence time unit; immutable.
+  RecurrenceUnit get recurrenceUnit;
+
+  /// Optional scheduling constraints (JSON array of [RecurrenceConstraint]);
+  /// immutable.
+  List<RecurrenceConstraint>? get recurrenceConstraints;
+
+  /// First occurrence date (Unix epoch days); immutable.
+  int get startDate;
+
+  /// Last valid occurrence date; immutable for recurring; computed for
+  /// installments.
+  int? get endDate;
+
+  /// Auto-posting behaviour; editable.
+  PostingBehaviour get postingBehaviour;
+
+  /// Transfer fee mode; null = no fee.
+  FeeMode? get feeMode;
+
+  /// Flat fee in minor units.
+  int? get feeAmountMinor;
+
+  /// Percentage fee × 1,000,000.
+  int? get feePercentageMicro;
+
+  /// Fee expense category UUID.
+  String? get feeCategoryId;
+
+  /// Resume-after epoch; null = not paused.
+  int? get pauseUntil;
+
+  /// Archival epoch; null = not archived.
+  int? get archivedAt;
+
+  /// Archival trigger; null = not archived.
+  ArchivedReason? get archivedReason;
+
+  /// Discriminator: false = recurring, true = installment.
+  bool get isInstallment;
+
+  /// Soft-delete flag.
+  bool get isDeleted;
+
+  /// Soft-delete epoch.
+  int? get deletedAt;
+
+  /// Creation epoch (Unix seconds).
+  int get createdAt;
+
+  /// Last-modified epoch (Unix seconds).
+  int get updatedAt;
+
+  /// JSON escape hatch.
+  String? get metadata;
+
+  /// Create a copy of RecurringTemplate
+  /// with the given fields replaced by the non-null parameter values.
+  @JsonKey(includeFromJson: false, includeToJson: false)
+  @pragma('vm:prefer-inline')
+  $RecurringTemplateCopyWith<RecurringTemplate> get copyWith =>
+      _$RecurringTemplateCopyWithImpl<RecurringTemplate>(
+          this as RecurringTemplate, _$identity);
+
+  @override
+  bool operator ==(Object other) {
+    return identical(this, other) ||
+        (other.runtimeType == runtimeType &&
+            other is RecurringTemplate &&
+            (identical(other.id, id) || other.id == id) &&
+            (identical(other.transactionType, transactionType) ||
+                other.transactionType == transactionType) &&
+            (identical(other.status, status) || other.status == status) &&
+            (identical(other.amountMinor, amountMinor) ||
+                other.amountMinor == amountMinor) &&
+            (identical(other.currencyCode, currencyCode) ||
+                other.currencyCode == currencyCode) &&
+            (identical(other.accountSourceId, accountSourceId) ||
+                other.accountSourceId == accountSourceId) &&
+            (identical(other.accountDestinationId, accountDestinationId) ||
+                other.accountDestinationId == accountDestinationId) &&
+            (identical(other.categoryId, categoryId) ||
+                other.categoryId == categoryId) &&
+            (identical(other.subcategoryId, subcategoryId) ||
+                other.subcategoryId == subcategoryId) &&
+            (identical(other.payeeId, payeeId) || other.payeeId == payeeId) &&
+            (identical(other.title, title) || other.title == title) &&
+            (identical(other.description, description) ||
+                other.description == description) &&
+            (identical(other.recurrenceN, recurrenceN) ||
+                other.recurrenceN == recurrenceN) &&
+            (identical(other.recurrenceUnit, recurrenceUnit) ||
+                other.recurrenceUnit == recurrenceUnit) &&
+            const DeepCollectionEquality()
+                .equals(other.recurrenceConstraints, recurrenceConstraints) &&
+            (identical(other.startDate, startDate) ||
+                other.startDate == startDate) &&
+            (identical(other.endDate, endDate) || other.endDate == endDate) &&
+            (identical(other.postingBehaviour, postingBehaviour) ||
+                other.postingBehaviour == postingBehaviour) &&
+            (identical(other.feeMode, feeMode) || other.feeMode == feeMode) &&
+            (identical(other.feeAmountMinor, feeAmountMinor) ||
+                other.feeAmountMinor == feeAmountMinor) &&
+            (identical(other.feePercentageMicro, feePercentageMicro) ||
+                other.feePercentageMicro == feePercentageMicro) &&
+            (identical(other.feeCategoryId, feeCategoryId) ||
+                other.feeCategoryId == feeCategoryId) &&
+            (identical(other.pauseUntil, pauseUntil) ||
+                other.pauseUntil == pauseUntil) &&
+            (identical(other.archivedAt, archivedAt) ||
+                other.archivedAt == archivedAt) &&
+            (identical(other.archivedReason, archivedReason) ||
+                other.archivedReason == archivedReason) &&
+            (identical(other.isInstallment, isInstallment) ||
+                other.isInstallment == isInstallment) &&
+            (identical(other.isDeleted, isDeleted) ||
+                other.isDeleted == isDeleted) &&
+            (identical(other.deletedAt, deletedAt) ||
+                other.deletedAt == deletedAt) &&
+            (identical(other.createdAt, createdAt) ||
+                other.createdAt == createdAt) &&
+            (identical(other.updatedAt, updatedAt) ||
+                other.updatedAt == updatedAt) &&
+            (identical(other.metadata, metadata) ||
+                other.metadata == metadata));
+  }
+
+  @override
+  int get hashCode => Object.hashAll([
+        runtimeType,
+        id,
+        transactionType,
+        status,
+        amountMinor,
+        currencyCode,
+        accountSourceId,
+        accountDestinationId,
+        categoryId,
+        subcategoryId,
+        payeeId,
+        title,
+        description,
+        recurrenceN,
+        recurrenceUnit,
+        const DeepCollectionEquality().hash(recurrenceConstraints),
+        startDate,
+        endDate,
+        postingBehaviour,
+        feeMode,
+        feeAmountMinor,
+        feePercentageMicro,
+        feeCategoryId,
+        pauseUntil,
+        archivedAt,
+        archivedReason,
+        isInstallment,
+        isDeleted,
+        deletedAt,
+        createdAt,
+        updatedAt,
+        metadata
+      ]);
+
+  @override
+  String toString() {
+    return 'RecurringTemplate(id: $id, transactionType: $transactionType, status: $status, amountMinor: $amountMinor, currencyCode: $currencyCode, accountSourceId: $accountSourceId, accountDestinationId: $accountDestinationId, categoryId: $categoryId, subcategoryId: $subcategoryId, payeeId: $payeeId, title: $title, description: $description, recurrenceN: $recurrenceN, recurrenceUnit: $recurrenceUnit, recurrenceConstraints: $recurrenceConstraints, startDate: $startDate, endDate: $endDate, postingBehaviour: $postingBehaviour, feeMode: $feeMode, feeAmountMinor: $feeAmountMinor, feePercentageMicro: $feePercentageMicro, feeCategoryId: $feeCategoryId, pauseUntil: $pauseUntil, archivedAt: $archivedAt, archivedReason: $archivedReason, isInstallment: $isInstallment, isDeleted: $isDeleted, deletedAt: $deletedAt, createdAt: $createdAt, updatedAt: $updatedAt, metadata: $metadata)';
+  }
+}
+
+/// @nodoc
+abstract mixin class $RecurringTemplateCopyWith<$Res> {
+  factory $RecurringTemplateCopyWith(
+          RecurringTemplate value, $Res Function(RecurringTemplate) _then) =
+      _$RecurringTemplateCopyWithImpl;
+  @useResult
+  $Res call(
+      {String id,
+      String transactionType,
+      RecurringTemplateStatus status,
+      int amountMinor,
+      String currencyCode,
+      String? accountSourceId,
+      String? accountDestinationId,
+      String? categoryId,
+      String? subcategoryId,
+      String? payeeId,
+      String? title,
+      String? description,
+      int recurrenceN,
+      RecurrenceUnit recurrenceUnit,
+      List<RecurrenceConstraint>? recurrenceConstraints,
+      int startDate,
+      int? endDate,
+      PostingBehaviour postingBehaviour,
+      FeeMode? feeMode,
+      int? feeAmountMinor,
+      int? feePercentageMicro,
+      String? feeCategoryId,
+      int? pauseUntil,
+      int? archivedAt,
+      ArchivedReason? archivedReason,
+      bool isInstallment,
+      bool isDeleted,
+      int? deletedAt,
+      int createdAt,
+      int updatedAt,
+      String? metadata});
+}
+
+/// @nodoc
+class _$RecurringTemplateCopyWithImpl<$Res>
+    implements $RecurringTemplateCopyWith<$Res> {
+  _$RecurringTemplateCopyWithImpl(this._self, this._then);
+
+  final RecurringTemplate _self;
+  final $Res Function(RecurringTemplate) _then;
+
+  /// Create a copy of RecurringTemplate
+  /// with the given fields replaced by the non-null parameter values.
+  @pragma('vm:prefer-inline')
+  @override
+  $Res call({
+    Object? id = null,
+    Object? transactionType = null,
+    Object? status = null,
+    Object? amountMinor = null,
+    Object? currencyCode = null,
+    Object? accountSourceId = freezed,
+    Object? accountDestinationId = freezed,
+    Object? categoryId = freezed,
+    Object? subcategoryId = freezed,
+    Object? payeeId = freezed,
+    Object? title = freezed,
+    Object? description = freezed,
+    Object? recurrenceN = null,
+    Object? recurrenceUnit = null,
+    Object? recurrenceConstraints = freezed,
+    Object? startDate = null,
+    Object? endDate = freezed,
+    Object? postingBehaviour = null,
+    Object? feeMode = freezed,
+    Object? feeAmountMinor = freezed,
+    Object? feePercentageMicro = freezed,
+    Object? feeCategoryId = freezed,
+    Object? pauseUntil = freezed,
+    Object? archivedAt = freezed,
+    Object? archivedReason = freezed,
+    Object? isInstallment = null,
+    Object? isDeleted = null,
+    Object? deletedAt = freezed,
+    Object? createdAt = null,
+    Object? updatedAt = null,
+    Object? metadata = freezed,
+  }) {
+    return _then(_self.copyWith(
+      id: null == id
+          ? _self.id
+          : id // ignore: cast_nullable_to_non_nullable
+              as String,
+      transactionType: null == transactionType
+          ? _self.transactionType
+          : transactionType // ignore: cast_nullable_to_non_nullable
+              as String,
+      status: null == status
+          ? _self.status
+          : status // ignore: cast_nullable_to_non_nullable
+              as RecurringTemplateStatus,
+      amountMinor: null == amountMinor
+          ? _self.amountMinor
+          : amountMinor // ignore: cast_nullable_to_non_nullable
+              as int,
+      currencyCode: null == currencyCode
+          ? _self.currencyCode
+          : currencyCode // ignore: cast_nullable_to_non_nullable
+              as String,
+      accountSourceId: freezed == accountSourceId
+          ? _self.accountSourceId
+          : accountSourceId // ignore: cast_nullable_to_non_nullable
+              as String?,
+      accountDestinationId: freezed == accountDestinationId
+          ? _self.accountDestinationId
+          : accountDestinationId // ignore: cast_nullable_to_non_nullable
+              as String?,
+      categoryId: freezed == categoryId
+          ? _self.categoryId
+          : categoryId // ignore: cast_nullable_to_non_nullable
+              as String?,
+      subcategoryId: freezed == subcategoryId
+          ? _self.subcategoryId
+          : subcategoryId // ignore: cast_nullable_to_non_nullable
+              as String?,
+      payeeId: freezed == payeeId
+          ? _self.payeeId
+          : payeeId // ignore: cast_nullable_to_non_nullable
+              as String?,
+      title: freezed == title
+          ? _self.title
+          : title // ignore: cast_nullable_to_non_nullable
+              as String?,
+      description: freezed == description
+          ? _self.description
+          : description // ignore: cast_nullable_to_non_nullable
+              as String?,
+      recurrenceN: null == recurrenceN
+          ? _self.recurrenceN
+          : recurrenceN // ignore: cast_nullable_to_non_nullable
+              as int,
+      recurrenceUnit: null == recurrenceUnit
+          ? _self.recurrenceUnit
+          : recurrenceUnit // ignore: cast_nullable_to_non_nullable
+              as RecurrenceUnit,
+      recurrenceConstraints: freezed == recurrenceConstraints
+          ? _self.recurrenceConstraints
+          : recurrenceConstraints // ignore: cast_nullable_to_non_nullable
+              as List<RecurrenceConstraint>?,
+      startDate: null == startDate
+          ? _self.startDate
+          : startDate // ignore: cast_nullable_to_non_nullable
+              as int,
+      endDate: freezed == endDate
+          ? _self.endDate
+          : endDate // ignore: cast_nullable_to_non_nullable
+              as int?,
+      postingBehaviour: null == postingBehaviour
+          ? _self.postingBehaviour
+          : postingBehaviour // ignore: cast_nullable_to_non_nullable
+              as PostingBehaviour,
+      feeMode: freezed == feeMode
+          ? _self.feeMode
+          : feeMode // ignore: cast_nullable_to_non_nullable
+              as FeeMode?,
+      feeAmountMinor: freezed == feeAmountMinor
+          ? _self.feeAmountMinor
+          : feeAmountMinor // ignore: cast_nullable_to_non_nullable
+              as int?,
+      feePercentageMicro: freezed == feePercentageMicro
+          ? _self.feePercentageMicro
+          : feePercentageMicro // ignore: cast_nullable_to_non_nullable
+              as int?,
+      feeCategoryId: freezed == feeCategoryId
+          ? _self.feeCategoryId
+          : feeCategoryId // ignore: cast_nullable_to_non_nullable
+              as String?,
+      pauseUntil: freezed == pauseUntil
+          ? _self.pauseUntil
+          : pauseUntil // ignore: cast_nullable_to_non_nullable
+              as int?,
+      archivedAt: freezed == archivedAt
+          ? _self.archivedAt
+          : archivedAt // ignore: cast_nullable_to_non_nullable
+              as int?,
+      archivedReason: freezed == archivedReason
+          ? _self.archivedReason
+          : archivedReason // ignore: cast_nullable_to_non_nullable
+              as ArchivedReason?,
+      isInstallment: null == isInstallment
+          ? _self.isInstallment
+          : isInstallment // ignore: cast_nullable_to_non_nullable
+              as bool,
+      isDeleted: null == isDeleted
+          ? _self.isDeleted
+          : isDeleted // ignore: cast_nullable_to_non_nullable
+              as bool,
+      deletedAt: freezed == deletedAt
+          ? _self.deletedAt
+          : deletedAt // ignore: cast_nullable_to_non_nullable
+              as int?,
+      createdAt: null == createdAt
+          ? _self.createdAt
+          : createdAt // ignore: cast_nullable_to_non_nullable
+              as int,
+      updatedAt: null == updatedAt
+          ? _self.updatedAt
+          : updatedAt // ignore: cast_nullable_to_non_nullable
+              as int,
+      metadata: freezed == metadata
+          ? _self.metadata
+          : metadata // ignore: cast_nullable_to_non_nullable
+              as String?,
+    ));
+  }
+}
+
+/// Adds pattern-matching-related methods to [RecurringTemplate].
+extension RecurringTemplatePatterns on RecurringTemplate {
+  /// A variant of `map` that fallback to returning `orElse`.
+  ///
+  /// It is equivalent to doing:
+  /// ```dart
+  /// switch (sealedClass) {
+  ///   case final Subclass value:
+  ///     return ...;
+  ///   case _:
+  ///     return orElse();
+  /// }
+  /// ```
+
+  @optionalTypeArgs
+  TResult maybeMap<TResult extends Object?>(
+    TResult Function(_RecurringTemplate value)? $default, {
+    required TResult orElse(),
+  }) {
+    final _that = this;
+    switch (_that) {
+      case _RecurringTemplate() when $default != null:
+        return $default(_that);
+      case _:
+        return orElse();
+    }
+  }
+
+  /// A `switch`-like method, using callbacks.
+  ///
+  /// Callbacks receives the raw object, upcasted.
+  /// It is equivalent to doing:
+  /// ```dart
+  /// switch (sealedClass) {
+  ///   case final Subclass value:
+  ///     return ...;
+  ///   case final Subclass2 value:
+  ///     return ...;
+  /// }
+  /// ```
+
+  @optionalTypeArgs
+  TResult map<TResult extends Object?>(
+    TResult Function(_RecurringTemplate value) $default,
+  ) {
+    final _that = this;
+    switch (_that) {
+      case _RecurringTemplate():
+        return $default(_that);
+      case _:
+        throw StateError('Unexpected subclass');
+    }
+  }
+
+  /// A variant of `map` that fallback to returning `null`.
+  ///
+  /// It is equivalent to doing:
+  /// ```dart
+  /// switch (sealedClass) {
+  ///   case final Subclass value:
+  ///     return ...;
+  ///   case _:
+  ///     return null;
+  /// }
+  /// ```
+
+  @optionalTypeArgs
+  TResult? mapOrNull<TResult extends Object?>(
+    TResult? Function(_RecurringTemplate value)? $default,
+  ) {
+    final _that = this;
+    switch (_that) {
+      case _RecurringTemplate() when $default != null:
+        return $default(_that);
+      case _:
+        return null;
+    }
+  }
+
+  /// A variant of `when` that fallback to an `orElse` callback.
+  ///
+  /// It is equivalent to doing:
+  /// ```dart
+  /// switch (sealedClass) {
+  ///   case Subclass(:final field):
+  ///     return ...;
+  ///   case _:
+  ///     return orElse();
+  /// }
+  /// ```
+
+  @optionalTypeArgs
+  TResult maybeWhen<TResult extends Object?>(
+    TResult Function(
+            String id,
+            String transactionType,
+            RecurringTemplateStatus status,
+            int amountMinor,
+            String currencyCode,
+            String? accountSourceId,
+            String? accountDestinationId,
+            String? categoryId,
+            String? subcategoryId,
+            String? payeeId,
+            String? title,
+            String? description,
+            int recurrenceN,
+            RecurrenceUnit recurrenceUnit,
+            List<RecurrenceConstraint>? recurrenceConstraints,
+            int startDate,
+            int? endDate,
+            PostingBehaviour postingBehaviour,
+            FeeMode? feeMode,
+            int? feeAmountMinor,
+            int? feePercentageMicro,
+            String? feeCategoryId,
+            int? pauseUntil,
+            int? archivedAt,
+            ArchivedReason? archivedReason,
+            bool isInstallment,
+            bool isDeleted,
+            int? deletedAt,
+            int createdAt,
+            int updatedAt,
+            String? metadata)?
+        $default, {
+    required TResult orElse(),
+  }) {
+    final _that = this;
+    switch (_that) {
+      case _RecurringTemplate() when $default != null:
+        return $default(
+            _that.id,
+            _that.transactionType,
+            _that.status,
+            _that.amountMinor,
+            _that.currencyCode,
+            _that.accountSourceId,
+            _that.accountDestinationId,
+            _that.categoryId,
+            _that.subcategoryId,
+            _that.payeeId,
+            _that.title,
+            _that.description,
+            _that.recurrenceN,
+            _that.recurrenceUnit,
+            _that.recurrenceConstraints,
+            _that.startDate,
+            _that.endDate,
+            _that.postingBehaviour,
+            _that.feeMode,
+            _that.feeAmountMinor,
+            _that.feePercentageMicro,
+            _that.feeCategoryId,
+            _that.pauseUntil,
+            _that.archivedAt,
+            _that.archivedReason,
+            _that.isInstallment,
+            _that.isDeleted,
+            _that.deletedAt,
+            _that.createdAt,
+            _that.updatedAt,
+            _that.metadata);
+      case _:
+        return orElse();
+    }
+  }
+
+  /// A `switch`-like method, using callbacks.
+  ///
+  /// As opposed to `map`, this offers destructuring.
+  /// It is equivalent to doing:
+  /// ```dart
+  /// switch (sealedClass) {
+  ///   case Subclass(:final field):
+  ///     return ...;
+  ///   case Subclass2(:final field2):
+  ///     return ...;
+  /// }
+  /// ```
+
+  @optionalTypeArgs
+  TResult when<TResult extends Object?>(
+    TResult Function(
+            String id,
+            String transactionType,
+            RecurringTemplateStatus status,
+            int amountMinor,
+            String currencyCode,
+            String? accountSourceId,
+            String? accountDestinationId,
+            String? categoryId,
+            String? subcategoryId,
+            String? payeeId,
+            String? title,
+            String? description,
+            int recurrenceN,
+            RecurrenceUnit recurrenceUnit,
+            List<RecurrenceConstraint>? recurrenceConstraints,
+            int startDate,
+            int? endDate,
+            PostingBehaviour postingBehaviour,
+            FeeMode? feeMode,
+            int? feeAmountMinor,
+            int? feePercentageMicro,
+            String? feeCategoryId,
+            int? pauseUntil,
+            int? archivedAt,
+            ArchivedReason? archivedReason,
+            bool isInstallment,
+            bool isDeleted,
+            int? deletedAt,
+            int createdAt,
+            int updatedAt,
+            String? metadata)
+        $default,
+  ) {
+    final _that = this;
+    switch (_that) {
+      case _RecurringTemplate():
+        return $default(
+            _that.id,
+            _that.transactionType,
+            _that.status,
+            _that.amountMinor,
+            _that.currencyCode,
+            _that.accountSourceId,
+            _that.accountDestinationId,
+            _that.categoryId,
+            _that.subcategoryId,
+            _that.payeeId,
+            _that.title,
+            _that.description,
+            _that.recurrenceN,
+            _that.recurrenceUnit,
+            _that.recurrenceConstraints,
+            _that.startDate,
+            _that.endDate,
+            _that.postingBehaviour,
+            _that.feeMode,
+            _that.feeAmountMinor,
+            _that.feePercentageMicro,
+            _that.feeCategoryId,
+            _that.pauseUntil,
+            _that.archivedAt,
+            _that.archivedReason,
+            _that.isInstallment,
+            _that.isDeleted,
+            _that.deletedAt,
+            _that.createdAt,
+            _that.updatedAt,
+            _that.metadata);
+      case _:
+        throw StateError('Unexpected subclass');
+    }
+  }
+
+  /// A variant of `when` that fallback to returning `null`
+  ///
+  /// It is equivalent to doing:
+  /// ```dart
+  /// switch (sealedClass) {
+  ///   case Subclass(:final field):
+  ///     return ...;
+  ///   case _:
+  ///     return null;
+  /// }
+  /// ```
+
+  @optionalTypeArgs
+  TResult? whenOrNull<TResult extends Object?>(
+    TResult? Function(
+            String id,
+            String transactionType,
+            RecurringTemplateStatus status,
+            int amountMinor,
+            String currencyCode,
+            String? accountSourceId,
+            String? accountDestinationId,
+            String? categoryId,
+            String? subcategoryId,
+            String? payeeId,
+            String? title,
+            String? description,
+            int recurrenceN,
+            RecurrenceUnit recurrenceUnit,
+            List<RecurrenceConstraint>? recurrenceConstraints,
+            int startDate,
+            int? endDate,
+            PostingBehaviour postingBehaviour,
+            FeeMode? feeMode,
+            int? feeAmountMinor,
+            int? feePercentageMicro,
+            String? feeCategoryId,
+            int? pauseUntil,
+            int? archivedAt,
+            ArchivedReason? archivedReason,
+            bool isInstallment,
+            bool isDeleted,
+            int? deletedAt,
+            int createdAt,
+            int updatedAt,
+            String? metadata)?
+        $default,
+  ) {
+    final _that = this;
+    switch (_that) {
+      case _RecurringTemplate() when $default != null:
+        return $default(
+            _that.id,
+            _that.transactionType,
+            _that.status,
+            _that.amountMinor,
+            _that.currencyCode,
+            _that.accountSourceId,
+            _that.accountDestinationId,
+            _that.categoryId,
+            _that.subcategoryId,
+            _that.payeeId,
+            _that.title,
+            _that.description,
+            _that.recurrenceN,
+            _that.recurrenceUnit,
+            _that.recurrenceConstraints,
+            _that.startDate,
+            _that.endDate,
+            _that.postingBehaviour,
+            _that.feeMode,
+            _that.feeAmountMinor,
+            _that.feePercentageMicro,
+            _that.feeCategoryId,
+            _that.pauseUntil,
+            _that.archivedAt,
+            _that.archivedReason,
+            _that.isInstallment,
+            _that.isDeleted,
+            _that.deletedAt,
+            _that.createdAt,
+            _that.updatedAt,
+            _that.metadata);
+      case _:
+        return null;
+    }
+  }
+}
+
+/// @nodoc
+
+class _RecurringTemplate implements RecurringTemplate {
+  const _RecurringTemplate(
+      {required this.id,
+      required this.transactionType,
+      this.status = RecurringTemplateStatus.active,
+      required this.amountMinor,
+      required this.currencyCode,
+      this.accountSourceId,
+      this.accountDestinationId,
+      this.categoryId,
+      this.subcategoryId,
+      this.payeeId,
+      this.title,
+      this.description,
+      required this.recurrenceN,
+      required this.recurrenceUnit,
+      final List<RecurrenceConstraint>? recurrenceConstraints,
+      required this.startDate,
+      this.endDate,
+      this.postingBehaviour = PostingBehaviour.autoPost,
+      this.feeMode,
+      this.feeAmountMinor,
+      this.feePercentageMicro,
+      this.feeCategoryId,
+      this.pauseUntil,
+      this.archivedAt,
+      this.archivedReason,
+      this.isInstallment = false,
+      this.isDeleted = false,
+      this.deletedAt,
+      required this.createdAt,
+      required this.updatedAt,
+      this.metadata})
+      : _recurrenceConstraints = recurrenceConstraints;
+
+  /// UUID v4 stable identifier.
+  @override
+  final String id;
+
+  /// Financial direction; immutable after creation.
+  @override
+  final String transactionType;
+
+  /// Lifecycle state.
+  @override
+  @JsonKey()
+  final RecurringTemplateStatus status;
+
+  /// Per-occurrence amount in minor units; in-place editable.
+  @override
+  final int amountMinor;
+
+  /// ISO 4217 code; derived from source account.
+  @override
+  final String currencyCode;
+
+  /// Source account UUID; null for income.
+  @override
+  final String? accountSourceId;
+
+  /// Destination account UUID; null for expense.
+  @override
+  final String? accountDestinationId;
+
+  /// Category UUID; null for transfer; editable.
+  @override
+  final String? categoryId;
+
+  /// Subcategory UUID; editable.
+  @override
+  final String? subcategoryId;
+
+  /// Payee UUID; optional.
+  @override
+  final String? payeeId;
+
+  /// Template title; editable.
+  @override
+  final String? title;
+
+  /// Description; editable.
+  @override
+  final String? description;
+
+  /// Cadence multiplier (e.g. 2 in "every 2 weeks"); immutable.
+  @override
+  final int recurrenceN;
+
+  /// Cadence time unit; immutable.
+  @override
+  final RecurrenceUnit recurrenceUnit;
+
+  /// Optional scheduling constraints (JSON array of [RecurrenceConstraint]);
+  /// immutable.
+  final List<RecurrenceConstraint>? _recurrenceConstraints;
+
+  /// Optional scheduling constraints (JSON array of [RecurrenceConstraint]);
+  /// immutable.
+  @override
+  List<RecurrenceConstraint>? get recurrenceConstraints {
+    final value = _recurrenceConstraints;
+    if (value == null) return null;
+    if (_recurrenceConstraints is EqualUnmodifiableListView)
+      return _recurrenceConstraints;
+    // ignore: implicit_dynamic_type
+    return EqualUnmodifiableListView(value);
+  }
+
+  /// First occurrence date (Unix epoch days); immutable.
+  @override
+  final int startDate;
+
+  /// Last valid occurrence date; immutable for recurring; computed for
+  /// installments.
+  @override
+  final int? endDate;
+
+  /// Auto-posting behaviour; editable.
+  @override
+  @JsonKey()
+  final PostingBehaviour postingBehaviour;
+
+  /// Transfer fee mode; null = no fee.
+  @override
+  final FeeMode? feeMode;
+
+  /// Flat fee in minor units.
+  @override
+  final int? feeAmountMinor;
+
+  /// Percentage fee × 1,000,000.
+  @override
+  final int? feePercentageMicro;
+
+  /// Fee expense category UUID.
+  @override
+  final String? feeCategoryId;
+
+  /// Resume-after epoch; null = not paused.
+  @override
+  final int? pauseUntil;
+
+  /// Archival epoch; null = not archived.
+  @override
+  final int? archivedAt;
+
+  /// Archival trigger; null = not archived.
+  @override
+  final ArchivedReason? archivedReason;
+
+  /// Discriminator: false = recurring, true = installment.
+  @override
+  @JsonKey()
+  final bool isInstallment;
+
+  /// Soft-delete flag.
+  @override
+  @JsonKey()
+  final bool isDeleted;
+
+  /// Soft-delete epoch.
+  @override
+  final int? deletedAt;
+
+  /// Creation epoch (Unix seconds).
+  @override
+  final int createdAt;
+
+  /// Last-modified epoch (Unix seconds).
+  @override
+  final int updatedAt;
+
+  /// JSON escape hatch.
+  @override
+  final String? metadata;
+
+  /// Create a copy of RecurringTemplate
+  /// with the given fields replaced by the non-null parameter values.
+  @override
+  @JsonKey(includeFromJson: false, includeToJson: false)
+  @pragma('vm:prefer-inline')
+  _$RecurringTemplateCopyWith<_RecurringTemplate> get copyWith =>
+      __$RecurringTemplateCopyWithImpl<_RecurringTemplate>(this, _$identity);
+
+  @override
+  bool operator ==(Object other) {
+    return identical(this, other) ||
+        (other.runtimeType == runtimeType &&
+            other is _RecurringTemplate &&
+            (identical(other.id, id) || other.id == id) &&
+            (identical(other.transactionType, transactionType) ||
+                other.transactionType == transactionType) &&
+            (identical(other.status, status) || other.status == status) &&
+            (identical(other.amountMinor, amountMinor) ||
+                other.amountMinor == amountMinor) &&
+            (identical(other.currencyCode, currencyCode) ||
+                other.currencyCode == currencyCode) &&
+            (identical(other.accountSourceId, accountSourceId) ||
+                other.accountSourceId == accountSourceId) &&
+            (identical(other.accountDestinationId, accountDestinationId) ||
+                other.accountDestinationId == accountDestinationId) &&
+            (identical(other.categoryId, categoryId) ||
+                other.categoryId == categoryId) &&
+            (identical(other.subcategoryId, subcategoryId) ||
+                other.subcategoryId == subcategoryId) &&
+            (identical(other.payeeId, payeeId) || other.payeeId == payeeId) &&
+            (identical(other.title, title) || other.title == title) &&
+            (identical(other.description, description) ||
+                other.description == description) &&
+            (identical(other.recurrenceN, recurrenceN) ||
+                other.recurrenceN == recurrenceN) &&
+            (identical(other.recurrenceUnit, recurrenceUnit) ||
+                other.recurrenceUnit == recurrenceUnit) &&
+            const DeepCollectionEquality()
+                .equals(other._recurrenceConstraints, _recurrenceConstraints) &&
+            (identical(other.startDate, startDate) ||
+                other.startDate == startDate) &&
+            (identical(other.endDate, endDate) || other.endDate == endDate) &&
+            (identical(other.postingBehaviour, postingBehaviour) ||
+                other.postingBehaviour == postingBehaviour) &&
+            (identical(other.feeMode, feeMode) || other.feeMode == feeMode) &&
+            (identical(other.feeAmountMinor, feeAmountMinor) ||
+                other.feeAmountMinor == feeAmountMinor) &&
+            (identical(other.feePercentageMicro, feePercentageMicro) ||
+                other.feePercentageMicro == feePercentageMicro) &&
+            (identical(other.feeCategoryId, feeCategoryId) ||
+                other.feeCategoryId == feeCategoryId) &&
+            (identical(other.pauseUntil, pauseUntil) ||
+                other.pauseUntil == pauseUntil) &&
+            (identical(other.archivedAt, archivedAt) ||
+                other.archivedAt == archivedAt) &&
+            (identical(other.archivedReason, archivedReason) ||
+                other.archivedReason == archivedReason) &&
+            (identical(other.isInstallment, isInstallment) ||
+                other.isInstallment == isInstallment) &&
+            (identical(other.isDeleted, isDeleted) ||
+                other.isDeleted == isDeleted) &&
+            (identical(other.deletedAt, deletedAt) ||
+                other.deletedAt == deletedAt) &&
+            (identical(other.createdAt, createdAt) ||
+                other.createdAt == createdAt) &&
+            (identical(other.updatedAt, updatedAt) ||
+                other.updatedAt == updatedAt) &&
+            (identical(other.metadata, metadata) ||
+                other.metadata == metadata));
+  }
+
+  @override
+  int get hashCode => Object.hashAll([
+        runtimeType,
+        id,
+        transactionType,
+        status,
+        amountMinor,
+        currencyCode,
+        accountSourceId,
+        accountDestinationId,
+        categoryId,
+        subcategoryId,
+        payeeId,
+        title,
+        description,
+        recurrenceN,
+        recurrenceUnit,
+        const DeepCollectionEquality().hash(_recurrenceConstraints),
+        startDate,
+        endDate,
+        postingBehaviour,
+        feeMode,
+        feeAmountMinor,
+        feePercentageMicro,
+        feeCategoryId,
+        pauseUntil,
+        archivedAt,
+        archivedReason,
+        isInstallment,
+        isDeleted,
+        deletedAt,
+        createdAt,
+        updatedAt,
+        metadata
+      ]);
+
+  @override
+  String toString() {
+    return 'RecurringTemplate(id: $id, transactionType: $transactionType, status: $status, amountMinor: $amountMinor, currencyCode: $currencyCode, accountSourceId: $accountSourceId, accountDestinationId: $accountDestinationId, categoryId: $categoryId, subcategoryId: $subcategoryId, payeeId: $payeeId, title: $title, description: $description, recurrenceN: $recurrenceN, recurrenceUnit: $recurrenceUnit, recurrenceConstraints: $recurrenceConstraints, startDate: $startDate, endDate: $endDate, postingBehaviour: $postingBehaviour, feeMode: $feeMode, feeAmountMinor: $feeAmountMinor, feePercentageMicro: $feePercentageMicro, feeCategoryId: $feeCategoryId, pauseUntil: $pauseUntil, archivedAt: $archivedAt, archivedReason: $archivedReason, isInstallment: $isInstallment, isDeleted: $isDeleted, deletedAt: $deletedAt, createdAt: $createdAt, updatedAt: $updatedAt, metadata: $metadata)';
+  }
+}
+
+/// @nodoc
+abstract mixin class _$RecurringTemplateCopyWith<$Res>
+    implements $RecurringTemplateCopyWith<$Res> {
+  factory _$RecurringTemplateCopyWith(
+          _RecurringTemplate value, $Res Function(_RecurringTemplate) _then) =
+      __$RecurringTemplateCopyWithImpl;
+  @override
+  @useResult
+  $Res call(
+      {String id,
+      String transactionType,
+      RecurringTemplateStatus status,
+      int amountMinor,
+      String currencyCode,
+      String? accountSourceId,
+      String? accountDestinationId,
+      String? categoryId,
+      String? subcategoryId,
+      String? payeeId,
+      String? title,
+      String? description,
+      int recurrenceN,
+      RecurrenceUnit recurrenceUnit,
+      List<RecurrenceConstraint>? recurrenceConstraints,
+      int startDate,
+      int? endDate,
+      PostingBehaviour postingBehaviour,
+      FeeMode? feeMode,
+      int? feeAmountMinor,
+      int? feePercentageMicro,
+      String? feeCategoryId,
+      int? pauseUntil,
+      int? archivedAt,
+      ArchivedReason? archivedReason,
+      bool isInstallment,
+      bool isDeleted,
+      int? deletedAt,
+      int createdAt,
+      int updatedAt,
+      String? metadata});
+}
+
+/// @nodoc
+class __$RecurringTemplateCopyWithImpl<$Res>
+    implements _$RecurringTemplateCopyWith<$Res> {
+  __$RecurringTemplateCopyWithImpl(this._self, this._then);
+
+  final _RecurringTemplate _self;
+  final $Res Function(_RecurringTemplate) _then;
+
+  /// Create a copy of RecurringTemplate
+  /// with the given fields replaced by the non-null parameter values.
+  @override
+  @pragma('vm:prefer-inline')
+  $Res call({
+    Object? id = null,
+    Object? transactionType = null,
+    Object? status = null,
+    Object? amountMinor = null,
+    Object? currencyCode = null,
+    Object? accountSourceId = freezed,
+    Object? accountDestinationId = freezed,
+    Object? categoryId = freezed,
+    Object? subcategoryId = freezed,
+    Object? payeeId = freezed,
+    Object? title = freezed,
+    Object? description = freezed,
+    Object? recurrenceN = null,
+    Object? recurrenceUnit = null,
+    Object? recurrenceConstraints = freezed,
+    Object? startDate = null,
+    Object? endDate = freezed,
+    Object? postingBehaviour = null,
+    Object? feeMode = freezed,
+    Object? feeAmountMinor = freezed,
+    Object? feePercentageMicro = freezed,
+    Object? feeCategoryId = freezed,
+    Object? pauseUntil = freezed,
+    Object? archivedAt = freezed,
+    Object? archivedReason = freezed,
+    Object? isInstallment = null,
+    Object? isDeleted = null,
+    Object? deletedAt = freezed,
+    Object? createdAt = null,
+    Object? updatedAt = null,
+    Object? metadata = freezed,
+  }) {
+    return _then(_RecurringTemplate(
+      id: null == id
+          ? _self.id
+          : id // ignore: cast_nullable_to_non_nullable
+              as String,
+      transactionType: null == transactionType
+          ? _self.transactionType
+          : transactionType // ignore: cast_nullable_to_non_nullable
+              as String,
+      status: null == status
+          ? _self.status
+          : status // ignore: cast_nullable_to_non_nullable
+              as RecurringTemplateStatus,
+      amountMinor: null == amountMinor
+          ? _self.amountMinor
+          : amountMinor // ignore: cast_nullable_to_non_nullable
+              as int,
+      currencyCode: null == currencyCode
+          ? _self.currencyCode
+          : currencyCode // ignore: cast_nullable_to_non_nullable
+              as String,
+      accountSourceId: freezed == accountSourceId
+          ? _self.accountSourceId
+          : accountSourceId // ignore: cast_nullable_to_non_nullable
+              as String?,
+      accountDestinationId: freezed == accountDestinationId
+          ? _self.accountDestinationId
+          : accountDestinationId // ignore: cast_nullable_to_non_nullable
+              as String?,
+      categoryId: freezed == categoryId
+          ? _self.categoryId
+          : categoryId // ignore: cast_nullable_to_non_nullable
+              as String?,
+      subcategoryId: freezed == subcategoryId
+          ? _self.subcategoryId
+          : subcategoryId // ignore: cast_nullable_to_non_nullable
+              as String?,
+      payeeId: freezed == payeeId
+          ? _self.payeeId
+          : payeeId // ignore: cast_nullable_to_non_nullable
+              as String?,
+      title: freezed == title
+          ? _self.title
+          : title // ignore: cast_nullable_to_non_nullable
+              as String?,
+      description: freezed == description
+          ? _self.description
+          : description // ignore: cast_nullable_to_non_nullable
+              as String?,
+      recurrenceN: null == recurrenceN
+          ? _self.recurrenceN
+          : recurrenceN // ignore: cast_nullable_to_non_nullable
+              as int,
+      recurrenceUnit: null == recurrenceUnit
+          ? _self.recurrenceUnit
+          : recurrenceUnit // ignore: cast_nullable_to_non_nullable
+              as RecurrenceUnit,
+      recurrenceConstraints: freezed == recurrenceConstraints
+          ? _self._recurrenceConstraints
+          : recurrenceConstraints // ignore: cast_nullable_to_non_nullable
+              as List<RecurrenceConstraint>?,
+      startDate: null == startDate
+          ? _self.startDate
+          : startDate // ignore: cast_nullable_to_non_nullable
+              as int,
+      endDate: freezed == endDate
+          ? _self.endDate
+          : endDate // ignore: cast_nullable_to_non_nullable
+              as int?,
+      postingBehaviour: null == postingBehaviour
+          ? _self.postingBehaviour
+          : postingBehaviour // ignore: cast_nullable_to_non_nullable
+              as PostingBehaviour,
+      feeMode: freezed == feeMode
+          ? _self.feeMode
+          : feeMode // ignore: cast_nullable_to_non_nullable
+              as FeeMode?,
+      feeAmountMinor: freezed == feeAmountMinor
+          ? _self.feeAmountMinor
+          : feeAmountMinor // ignore: cast_nullable_to_non_nullable
+              as int?,
+      feePercentageMicro: freezed == feePercentageMicro
+          ? _self.feePercentageMicro
+          : feePercentageMicro // ignore: cast_nullable_to_non_nullable
+              as int?,
+      feeCategoryId: freezed == feeCategoryId
+          ? _self.feeCategoryId
+          : feeCategoryId // ignore: cast_nullable_to_non_nullable
+              as String?,
+      pauseUntil: freezed == pauseUntil
+          ? _self.pauseUntil
+          : pauseUntil // ignore: cast_nullable_to_non_nullable
+              as int?,
+      archivedAt: freezed == archivedAt
+          ? _self.archivedAt
+          : archivedAt // ignore: cast_nullable_to_non_nullable
+              as int?,
+      archivedReason: freezed == archivedReason
+          ? _self.archivedReason
+          : archivedReason // ignore: cast_nullable_to_non_nullable
+              as ArchivedReason?,
+      isInstallment: null == isInstallment
+          ? _self.isInstallment
+          : isInstallment // ignore: cast_nullable_to_non_nullable
+              as bool,
+      isDeleted: null == isDeleted
+          ? _self.isDeleted
+          : isDeleted // ignore: cast_nullable_to_non_nullable
+              as bool,
+      deletedAt: freezed == deletedAt
+          ? _self.deletedAt
+          : deletedAt // ignore: cast_nullable_to_non_nullable
+              as int?,
+      createdAt: null == createdAt
+          ? _self.createdAt
+          : createdAt // ignore: cast_nullable_to_non_nullable
+              as int,
+      updatedAt: null == updatedAt
+          ? _self.updatedAt
+          : updatedAt // ignore: cast_nullable_to_non_nullable
+              as int,
+      metadata: freezed == metadata
+          ? _self.metadata
+          : metadata // ignore: cast_nullable_to_non_nullable
+              as String?,
+    ));
+  }
+}
+
+// dart format on

--- a/lib/domain/entities/scheduled_occurrence.dart
+++ b/lib/domain/entities/scheduled_occurrence.dart
@@ -1,0 +1,49 @@
+// lib/domain/entities/scheduled_occurrence.dart
+//
+// ScheduledOccurrence domain entity.
+//
+// Materialized occurrence record for a recurring (non-installment) template.
+// One row per expected occurrence. Provides the exception list for the
+// scheduler (TC-003) and enables per-occurrence status tracking.
+//
+// Lookahead window: occurrences are materialized up to 90 days ahead.
+
+import 'package:freezed_annotation/freezed_annotation.dart';
+
+part 'scheduled_occurrence.freezed.dart';
+
+/// Lifecycle state of a scheduled occurrence.
+enum ScheduledOccurrenceStatus {
+  pending,
+  posted,
+  skipped,
+  cancelled,
+}
+
+/// Immutable domain entity for a single materialized recurring occurrence.
+@freezed
+abstract class ScheduledOccurrence with _$ScheduledOccurrence {
+  const factory ScheduledOccurrence({
+    /// UUID v4 stable identifier.
+    required String id,
+
+    /// Parent template UUID.
+    required String templateId,
+
+    /// Unix epoch date when this occurrence should fire.
+    required int scheduledDate,
+
+    /// Lifecycle status.
+    @Default(ScheduledOccurrenceStatus.pending)
+    ScheduledOccurrenceStatus status,
+
+    /// Transaction UUID once the occurrence is posted.
+    String? childTransactionId,
+
+    /// Creation epoch (Unix seconds).
+    required int createdAt,
+
+    /// Last-modified epoch (Unix seconds).
+    required int updatedAt,
+  }) = _ScheduledOccurrence;
+}

--- a/lib/domain/entities/scheduled_occurrence.freezed.dart
+++ b/lib/domain/entities/scheduled_occurrence.freezed.dart
@@ -1,0 +1,498 @@
+// GENERATED CODE - DO NOT MODIFY BY HAND
+// coverage:ignore-file
+// ignore_for_file: type=lint
+// ignore_for_file: unused_element, deprecated_member_use, deprecated_member_use_from_same_package, use_function_type_syntax_for_parameters, unnecessary_const, avoid_init_to_null, invalid_override_different_default_values_named, prefer_expression_function_bodies, annotate_overrides, invalid_annotation_target, unnecessary_question_mark
+
+part of 'scheduled_occurrence.dart';
+
+// **************************************************************************
+// FreezedGenerator
+// **************************************************************************
+
+// dart format off
+T _$identity<T>(T value) => value;
+
+/// @nodoc
+mixin _$ScheduledOccurrence {
+  /// UUID v4 stable identifier.
+  String get id;
+
+  /// Parent template UUID.
+  String get templateId;
+
+  /// Unix epoch date when this occurrence should fire.
+  int get scheduledDate;
+
+  /// Lifecycle status.
+  ScheduledOccurrenceStatus get status;
+
+  /// Transaction UUID once the occurrence is posted.
+  String? get childTransactionId;
+
+  /// Creation epoch (Unix seconds).
+  int get createdAt;
+
+  /// Last-modified epoch (Unix seconds).
+  int get updatedAt;
+
+  /// Create a copy of ScheduledOccurrence
+  /// with the given fields replaced by the non-null parameter values.
+  @JsonKey(includeFromJson: false, includeToJson: false)
+  @pragma('vm:prefer-inline')
+  $ScheduledOccurrenceCopyWith<ScheduledOccurrence> get copyWith =>
+      _$ScheduledOccurrenceCopyWithImpl<ScheduledOccurrence>(
+          this as ScheduledOccurrence, _$identity);
+
+  @override
+  bool operator ==(Object other) {
+    return identical(this, other) ||
+        (other.runtimeType == runtimeType &&
+            other is ScheduledOccurrence &&
+            (identical(other.id, id) || other.id == id) &&
+            (identical(other.templateId, templateId) ||
+                other.templateId == templateId) &&
+            (identical(other.scheduledDate, scheduledDate) ||
+                other.scheduledDate == scheduledDate) &&
+            (identical(other.status, status) || other.status == status) &&
+            (identical(other.childTransactionId, childTransactionId) ||
+                other.childTransactionId == childTransactionId) &&
+            (identical(other.createdAt, createdAt) ||
+                other.createdAt == createdAt) &&
+            (identical(other.updatedAt, updatedAt) ||
+                other.updatedAt == updatedAt));
+  }
+
+  @override
+  int get hashCode => Object.hash(runtimeType, id, templateId, scheduledDate,
+      status, childTransactionId, createdAt, updatedAt);
+
+  @override
+  String toString() {
+    return 'ScheduledOccurrence(id: $id, templateId: $templateId, scheduledDate: $scheduledDate, status: $status, childTransactionId: $childTransactionId, createdAt: $createdAt, updatedAt: $updatedAt)';
+  }
+}
+
+/// @nodoc
+abstract mixin class $ScheduledOccurrenceCopyWith<$Res> {
+  factory $ScheduledOccurrenceCopyWith(
+          ScheduledOccurrence value, $Res Function(ScheduledOccurrence) _then) =
+      _$ScheduledOccurrenceCopyWithImpl;
+  @useResult
+  $Res call(
+      {String id,
+      String templateId,
+      int scheduledDate,
+      ScheduledOccurrenceStatus status,
+      String? childTransactionId,
+      int createdAt,
+      int updatedAt});
+}
+
+/// @nodoc
+class _$ScheduledOccurrenceCopyWithImpl<$Res>
+    implements $ScheduledOccurrenceCopyWith<$Res> {
+  _$ScheduledOccurrenceCopyWithImpl(this._self, this._then);
+
+  final ScheduledOccurrence _self;
+  final $Res Function(ScheduledOccurrence) _then;
+
+  /// Create a copy of ScheduledOccurrence
+  /// with the given fields replaced by the non-null parameter values.
+  @pragma('vm:prefer-inline')
+  @override
+  $Res call({
+    Object? id = null,
+    Object? templateId = null,
+    Object? scheduledDate = null,
+    Object? status = null,
+    Object? childTransactionId = freezed,
+    Object? createdAt = null,
+    Object? updatedAt = null,
+  }) {
+    return _then(_self.copyWith(
+      id: null == id
+          ? _self.id
+          : id // ignore: cast_nullable_to_non_nullable
+              as String,
+      templateId: null == templateId
+          ? _self.templateId
+          : templateId // ignore: cast_nullable_to_non_nullable
+              as String,
+      scheduledDate: null == scheduledDate
+          ? _self.scheduledDate
+          : scheduledDate // ignore: cast_nullable_to_non_nullable
+              as int,
+      status: null == status
+          ? _self.status
+          : status // ignore: cast_nullable_to_non_nullable
+              as ScheduledOccurrenceStatus,
+      childTransactionId: freezed == childTransactionId
+          ? _self.childTransactionId
+          : childTransactionId // ignore: cast_nullable_to_non_nullable
+              as String?,
+      createdAt: null == createdAt
+          ? _self.createdAt
+          : createdAt // ignore: cast_nullable_to_non_nullable
+              as int,
+      updatedAt: null == updatedAt
+          ? _self.updatedAt
+          : updatedAt // ignore: cast_nullable_to_non_nullable
+              as int,
+    ));
+  }
+}
+
+/// Adds pattern-matching-related methods to [ScheduledOccurrence].
+extension ScheduledOccurrencePatterns on ScheduledOccurrence {
+  /// A variant of `map` that fallback to returning `orElse`.
+  ///
+  /// It is equivalent to doing:
+  /// ```dart
+  /// switch (sealedClass) {
+  ///   case final Subclass value:
+  ///     return ...;
+  ///   case _:
+  ///     return orElse();
+  /// }
+  /// ```
+
+  @optionalTypeArgs
+  TResult maybeMap<TResult extends Object?>(
+    TResult Function(_ScheduledOccurrence value)? $default, {
+    required TResult orElse(),
+  }) {
+    final _that = this;
+    switch (_that) {
+      case _ScheduledOccurrence() when $default != null:
+        return $default(_that);
+      case _:
+        return orElse();
+    }
+  }
+
+  /// A `switch`-like method, using callbacks.
+  ///
+  /// Callbacks receives the raw object, upcasted.
+  /// It is equivalent to doing:
+  /// ```dart
+  /// switch (sealedClass) {
+  ///   case final Subclass value:
+  ///     return ...;
+  ///   case final Subclass2 value:
+  ///     return ...;
+  /// }
+  /// ```
+
+  @optionalTypeArgs
+  TResult map<TResult extends Object?>(
+    TResult Function(_ScheduledOccurrence value) $default,
+  ) {
+    final _that = this;
+    switch (_that) {
+      case _ScheduledOccurrence():
+        return $default(_that);
+      case _:
+        throw StateError('Unexpected subclass');
+    }
+  }
+
+  /// A variant of `map` that fallback to returning `null`.
+  ///
+  /// It is equivalent to doing:
+  /// ```dart
+  /// switch (sealedClass) {
+  ///   case final Subclass value:
+  ///     return ...;
+  ///   case _:
+  ///     return null;
+  /// }
+  /// ```
+
+  @optionalTypeArgs
+  TResult? mapOrNull<TResult extends Object?>(
+    TResult? Function(_ScheduledOccurrence value)? $default,
+  ) {
+    final _that = this;
+    switch (_that) {
+      case _ScheduledOccurrence() when $default != null:
+        return $default(_that);
+      case _:
+        return null;
+    }
+  }
+
+  /// A variant of `when` that fallback to an `orElse` callback.
+  ///
+  /// It is equivalent to doing:
+  /// ```dart
+  /// switch (sealedClass) {
+  ///   case Subclass(:final field):
+  ///     return ...;
+  ///   case _:
+  ///     return orElse();
+  /// }
+  /// ```
+
+  @optionalTypeArgs
+  TResult maybeWhen<TResult extends Object?>(
+    TResult Function(
+            String id,
+            String templateId,
+            int scheduledDate,
+            ScheduledOccurrenceStatus status,
+            String? childTransactionId,
+            int createdAt,
+            int updatedAt)?
+        $default, {
+    required TResult orElse(),
+  }) {
+    final _that = this;
+    switch (_that) {
+      case _ScheduledOccurrence() when $default != null:
+        return $default(
+            _that.id,
+            _that.templateId,
+            _that.scheduledDate,
+            _that.status,
+            _that.childTransactionId,
+            _that.createdAt,
+            _that.updatedAt);
+      case _:
+        return orElse();
+    }
+  }
+
+  /// A `switch`-like method, using callbacks.
+  ///
+  /// As opposed to `map`, this offers destructuring.
+  /// It is equivalent to doing:
+  /// ```dart
+  /// switch (sealedClass) {
+  ///   case Subclass(:final field):
+  ///     return ...;
+  ///   case Subclass2(:final field2):
+  ///     return ...;
+  /// }
+  /// ```
+
+  @optionalTypeArgs
+  TResult when<TResult extends Object?>(
+    TResult Function(
+            String id,
+            String templateId,
+            int scheduledDate,
+            ScheduledOccurrenceStatus status,
+            String? childTransactionId,
+            int createdAt,
+            int updatedAt)
+        $default,
+  ) {
+    final _that = this;
+    switch (_that) {
+      case _ScheduledOccurrence():
+        return $default(
+            _that.id,
+            _that.templateId,
+            _that.scheduledDate,
+            _that.status,
+            _that.childTransactionId,
+            _that.createdAt,
+            _that.updatedAt);
+      case _:
+        throw StateError('Unexpected subclass');
+    }
+  }
+
+  /// A variant of `when` that fallback to returning `null`
+  ///
+  /// It is equivalent to doing:
+  /// ```dart
+  /// switch (sealedClass) {
+  ///   case Subclass(:final field):
+  ///     return ...;
+  ///   case _:
+  ///     return null;
+  /// }
+  /// ```
+
+  @optionalTypeArgs
+  TResult? whenOrNull<TResult extends Object?>(
+    TResult? Function(
+            String id,
+            String templateId,
+            int scheduledDate,
+            ScheduledOccurrenceStatus status,
+            String? childTransactionId,
+            int createdAt,
+            int updatedAt)?
+        $default,
+  ) {
+    final _that = this;
+    switch (_that) {
+      case _ScheduledOccurrence() when $default != null:
+        return $default(
+            _that.id,
+            _that.templateId,
+            _that.scheduledDate,
+            _that.status,
+            _that.childTransactionId,
+            _that.createdAt,
+            _that.updatedAt);
+      case _:
+        return null;
+    }
+  }
+}
+
+/// @nodoc
+
+class _ScheduledOccurrence implements ScheduledOccurrence {
+  const _ScheduledOccurrence(
+      {required this.id,
+      required this.templateId,
+      required this.scheduledDate,
+      this.status = ScheduledOccurrenceStatus.pending,
+      this.childTransactionId,
+      required this.createdAt,
+      required this.updatedAt});
+
+  /// UUID v4 stable identifier.
+  @override
+  final String id;
+
+  /// Parent template UUID.
+  @override
+  final String templateId;
+
+  /// Unix epoch date when this occurrence should fire.
+  @override
+  final int scheduledDate;
+
+  /// Lifecycle status.
+  @override
+  @JsonKey()
+  final ScheduledOccurrenceStatus status;
+
+  /// Transaction UUID once the occurrence is posted.
+  @override
+  final String? childTransactionId;
+
+  /// Creation epoch (Unix seconds).
+  @override
+  final int createdAt;
+
+  /// Last-modified epoch (Unix seconds).
+  @override
+  final int updatedAt;
+
+  /// Create a copy of ScheduledOccurrence
+  /// with the given fields replaced by the non-null parameter values.
+  @override
+  @JsonKey(includeFromJson: false, includeToJson: false)
+  @pragma('vm:prefer-inline')
+  _$ScheduledOccurrenceCopyWith<_ScheduledOccurrence> get copyWith =>
+      __$ScheduledOccurrenceCopyWithImpl<_ScheduledOccurrence>(
+          this, _$identity);
+
+  @override
+  bool operator ==(Object other) {
+    return identical(this, other) ||
+        (other.runtimeType == runtimeType &&
+            other is _ScheduledOccurrence &&
+            (identical(other.id, id) || other.id == id) &&
+            (identical(other.templateId, templateId) ||
+                other.templateId == templateId) &&
+            (identical(other.scheduledDate, scheduledDate) ||
+                other.scheduledDate == scheduledDate) &&
+            (identical(other.status, status) || other.status == status) &&
+            (identical(other.childTransactionId, childTransactionId) ||
+                other.childTransactionId == childTransactionId) &&
+            (identical(other.createdAt, createdAt) ||
+                other.createdAt == createdAt) &&
+            (identical(other.updatedAt, updatedAt) ||
+                other.updatedAt == updatedAt));
+  }
+
+  @override
+  int get hashCode => Object.hash(runtimeType, id, templateId, scheduledDate,
+      status, childTransactionId, createdAt, updatedAt);
+
+  @override
+  String toString() {
+    return 'ScheduledOccurrence(id: $id, templateId: $templateId, scheduledDate: $scheduledDate, status: $status, childTransactionId: $childTransactionId, createdAt: $createdAt, updatedAt: $updatedAt)';
+  }
+}
+
+/// @nodoc
+abstract mixin class _$ScheduledOccurrenceCopyWith<$Res>
+    implements $ScheduledOccurrenceCopyWith<$Res> {
+  factory _$ScheduledOccurrenceCopyWith(_ScheduledOccurrence value,
+          $Res Function(_ScheduledOccurrence) _then) =
+      __$ScheduledOccurrenceCopyWithImpl;
+  @override
+  @useResult
+  $Res call(
+      {String id,
+      String templateId,
+      int scheduledDate,
+      ScheduledOccurrenceStatus status,
+      String? childTransactionId,
+      int createdAt,
+      int updatedAt});
+}
+
+/// @nodoc
+class __$ScheduledOccurrenceCopyWithImpl<$Res>
+    implements _$ScheduledOccurrenceCopyWith<$Res> {
+  __$ScheduledOccurrenceCopyWithImpl(this._self, this._then);
+
+  final _ScheduledOccurrence _self;
+  final $Res Function(_ScheduledOccurrence) _then;
+
+  /// Create a copy of ScheduledOccurrence
+  /// with the given fields replaced by the non-null parameter values.
+  @override
+  @pragma('vm:prefer-inline')
+  $Res call({
+    Object? id = null,
+    Object? templateId = null,
+    Object? scheduledDate = null,
+    Object? status = null,
+    Object? childTransactionId = freezed,
+    Object? createdAt = null,
+    Object? updatedAt = null,
+  }) {
+    return _then(_ScheduledOccurrence(
+      id: null == id
+          ? _self.id
+          : id // ignore: cast_nullable_to_non_nullable
+              as String,
+      templateId: null == templateId
+          ? _self.templateId
+          : templateId // ignore: cast_nullable_to_non_nullable
+              as String,
+      scheduledDate: null == scheduledDate
+          ? _self.scheduledDate
+          : scheduledDate // ignore: cast_nullable_to_non_nullable
+              as int,
+      status: null == status
+          ? _self.status
+          : status // ignore: cast_nullable_to_non_nullable
+              as ScheduledOccurrenceStatus,
+      childTransactionId: freezed == childTransactionId
+          ? _self.childTransactionId
+          : childTransactionId // ignore: cast_nullable_to_non_nullable
+              as String?,
+      createdAt: null == createdAt
+          ? _self.createdAt
+          : createdAt // ignore: cast_nullable_to_non_nullable
+              as int,
+      updatedAt: null == updatedAt
+          ? _self.updatedAt
+          : updatedAt // ignore: cast_nullable_to_non_nullable
+              as int,
+    ));
+  }
+}
+
+// dart format on

--- a/lib/domain/entities/tag.dart
+++ b/lib/domain/entities/tag.dart
@@ -1,0 +1,25 @@
+// lib/domain/entities/tag.dart
+//
+// Tag domain entity.
+//
+// Free-form tags for cross-cutting transaction grouping (many-to-many).
+// Schema-ready in v1 but not surfaced in the v1 UI.
+
+import 'package:freezed_annotation/freezed_annotation.dart';
+
+part 'tag.freezed.dart';
+
+/// Immutable domain entity for a transaction tag.
+@freezed
+abstract class Tag with _$Tag {
+  const factory Tag({
+    /// UUID v4 stable identifier.
+    required String id,
+
+    /// Tag label; unique (case-insensitive enforced at app layer).
+    required String name,
+
+    /// Creation epoch (Unix seconds).
+    required int createdAt,
+  }) = _Tag;
+}

--- a/lib/domain/entities/tag.freezed.dart
+++ b/lib/domain/entities/tag.freezed.dart
@@ -1,0 +1,337 @@
+// GENERATED CODE - DO NOT MODIFY BY HAND
+// coverage:ignore-file
+// ignore_for_file: type=lint
+// ignore_for_file: unused_element, deprecated_member_use, deprecated_member_use_from_same_package, use_function_type_syntax_for_parameters, unnecessary_const, avoid_init_to_null, invalid_override_different_default_values_named, prefer_expression_function_bodies, annotate_overrides, invalid_annotation_target, unnecessary_question_mark
+
+part of 'tag.dart';
+
+// **************************************************************************
+// FreezedGenerator
+// **************************************************************************
+
+// dart format off
+T _$identity<T>(T value) => value;
+
+/// @nodoc
+mixin _$Tag {
+  /// UUID v4 stable identifier.
+  String get id;
+
+  /// Tag label; unique (case-insensitive enforced at app layer).
+  String get name;
+
+  /// Creation epoch (Unix seconds).
+  int get createdAt;
+
+  /// Create a copy of Tag
+  /// with the given fields replaced by the non-null parameter values.
+  @JsonKey(includeFromJson: false, includeToJson: false)
+  @pragma('vm:prefer-inline')
+  $TagCopyWith<Tag> get copyWith =>
+      _$TagCopyWithImpl<Tag>(this as Tag, _$identity);
+
+  @override
+  bool operator ==(Object other) {
+    return identical(this, other) ||
+        (other.runtimeType == runtimeType &&
+            other is Tag &&
+            (identical(other.id, id) || other.id == id) &&
+            (identical(other.name, name) || other.name == name) &&
+            (identical(other.createdAt, createdAt) ||
+                other.createdAt == createdAt));
+  }
+
+  @override
+  int get hashCode => Object.hash(runtimeType, id, name, createdAt);
+
+  @override
+  String toString() {
+    return 'Tag(id: $id, name: $name, createdAt: $createdAt)';
+  }
+}
+
+/// @nodoc
+abstract mixin class $TagCopyWith<$Res> {
+  factory $TagCopyWith(Tag value, $Res Function(Tag) _then) = _$TagCopyWithImpl;
+  @useResult
+  $Res call({String id, String name, int createdAt});
+}
+
+/// @nodoc
+class _$TagCopyWithImpl<$Res> implements $TagCopyWith<$Res> {
+  _$TagCopyWithImpl(this._self, this._then);
+
+  final Tag _self;
+  final $Res Function(Tag) _then;
+
+  /// Create a copy of Tag
+  /// with the given fields replaced by the non-null parameter values.
+  @pragma('vm:prefer-inline')
+  @override
+  $Res call({
+    Object? id = null,
+    Object? name = null,
+    Object? createdAt = null,
+  }) {
+    return _then(_self.copyWith(
+      id: null == id
+          ? _self.id
+          : id // ignore: cast_nullable_to_non_nullable
+              as String,
+      name: null == name
+          ? _self.name
+          : name // ignore: cast_nullable_to_non_nullable
+              as String,
+      createdAt: null == createdAt
+          ? _self.createdAt
+          : createdAt // ignore: cast_nullable_to_non_nullable
+              as int,
+    ));
+  }
+}
+
+/// Adds pattern-matching-related methods to [Tag].
+extension TagPatterns on Tag {
+  /// A variant of `map` that fallback to returning `orElse`.
+  ///
+  /// It is equivalent to doing:
+  /// ```dart
+  /// switch (sealedClass) {
+  ///   case final Subclass value:
+  ///     return ...;
+  ///   case _:
+  ///     return orElse();
+  /// }
+  /// ```
+
+  @optionalTypeArgs
+  TResult maybeMap<TResult extends Object?>(
+    TResult Function(_Tag value)? $default, {
+    required TResult orElse(),
+  }) {
+    final _that = this;
+    switch (_that) {
+      case _Tag() when $default != null:
+        return $default(_that);
+      case _:
+        return orElse();
+    }
+  }
+
+  /// A `switch`-like method, using callbacks.
+  ///
+  /// Callbacks receives the raw object, upcasted.
+  /// It is equivalent to doing:
+  /// ```dart
+  /// switch (sealedClass) {
+  ///   case final Subclass value:
+  ///     return ...;
+  ///   case final Subclass2 value:
+  ///     return ...;
+  /// }
+  /// ```
+
+  @optionalTypeArgs
+  TResult map<TResult extends Object?>(
+    TResult Function(_Tag value) $default,
+  ) {
+    final _that = this;
+    switch (_that) {
+      case _Tag():
+        return $default(_that);
+      case _:
+        throw StateError('Unexpected subclass');
+    }
+  }
+
+  /// A variant of `map` that fallback to returning `null`.
+  ///
+  /// It is equivalent to doing:
+  /// ```dart
+  /// switch (sealedClass) {
+  ///   case final Subclass value:
+  ///     return ...;
+  ///   case _:
+  ///     return null;
+  /// }
+  /// ```
+
+  @optionalTypeArgs
+  TResult? mapOrNull<TResult extends Object?>(
+    TResult? Function(_Tag value)? $default,
+  ) {
+    final _that = this;
+    switch (_that) {
+      case _Tag() when $default != null:
+        return $default(_that);
+      case _:
+        return null;
+    }
+  }
+
+  /// A variant of `when` that fallback to an `orElse` callback.
+  ///
+  /// It is equivalent to doing:
+  /// ```dart
+  /// switch (sealedClass) {
+  ///   case Subclass(:final field):
+  ///     return ...;
+  ///   case _:
+  ///     return orElse();
+  /// }
+  /// ```
+
+  @optionalTypeArgs
+  TResult maybeWhen<TResult extends Object?>(
+    TResult Function(String id, String name, int createdAt)? $default, {
+    required TResult orElse(),
+  }) {
+    final _that = this;
+    switch (_that) {
+      case _Tag() when $default != null:
+        return $default(_that.id, _that.name, _that.createdAt);
+      case _:
+        return orElse();
+    }
+  }
+
+  /// A `switch`-like method, using callbacks.
+  ///
+  /// As opposed to `map`, this offers destructuring.
+  /// It is equivalent to doing:
+  /// ```dart
+  /// switch (sealedClass) {
+  ///   case Subclass(:final field):
+  ///     return ...;
+  ///   case Subclass2(:final field2):
+  ///     return ...;
+  /// }
+  /// ```
+
+  @optionalTypeArgs
+  TResult when<TResult extends Object?>(
+    TResult Function(String id, String name, int createdAt) $default,
+  ) {
+    final _that = this;
+    switch (_that) {
+      case _Tag():
+        return $default(_that.id, _that.name, _that.createdAt);
+      case _:
+        throw StateError('Unexpected subclass');
+    }
+  }
+
+  /// A variant of `when` that fallback to returning `null`
+  ///
+  /// It is equivalent to doing:
+  /// ```dart
+  /// switch (sealedClass) {
+  ///   case Subclass(:final field):
+  ///     return ...;
+  ///   case _:
+  ///     return null;
+  /// }
+  /// ```
+
+  @optionalTypeArgs
+  TResult? whenOrNull<TResult extends Object?>(
+    TResult? Function(String id, String name, int createdAt)? $default,
+  ) {
+    final _that = this;
+    switch (_that) {
+      case _Tag() when $default != null:
+        return $default(_that.id, _that.name, _that.createdAt);
+      case _:
+        return null;
+    }
+  }
+}
+
+/// @nodoc
+
+class _Tag implements Tag {
+  const _Tag({required this.id, required this.name, required this.createdAt});
+
+  /// UUID v4 stable identifier.
+  @override
+  final String id;
+
+  /// Tag label; unique (case-insensitive enforced at app layer).
+  @override
+  final String name;
+
+  /// Creation epoch (Unix seconds).
+  @override
+  final int createdAt;
+
+  /// Create a copy of Tag
+  /// with the given fields replaced by the non-null parameter values.
+  @override
+  @JsonKey(includeFromJson: false, includeToJson: false)
+  @pragma('vm:prefer-inline')
+  _$TagCopyWith<_Tag> get copyWith =>
+      __$TagCopyWithImpl<_Tag>(this, _$identity);
+
+  @override
+  bool operator ==(Object other) {
+    return identical(this, other) ||
+        (other.runtimeType == runtimeType &&
+            other is _Tag &&
+            (identical(other.id, id) || other.id == id) &&
+            (identical(other.name, name) || other.name == name) &&
+            (identical(other.createdAt, createdAt) ||
+                other.createdAt == createdAt));
+  }
+
+  @override
+  int get hashCode => Object.hash(runtimeType, id, name, createdAt);
+
+  @override
+  String toString() {
+    return 'Tag(id: $id, name: $name, createdAt: $createdAt)';
+  }
+}
+
+/// @nodoc
+abstract mixin class _$TagCopyWith<$Res> implements $TagCopyWith<$Res> {
+  factory _$TagCopyWith(_Tag value, $Res Function(_Tag) _then) =
+      __$TagCopyWithImpl;
+  @override
+  @useResult
+  $Res call({String id, String name, int createdAt});
+}
+
+/// @nodoc
+class __$TagCopyWithImpl<$Res> implements _$TagCopyWith<$Res> {
+  __$TagCopyWithImpl(this._self, this._then);
+
+  final _Tag _self;
+  final $Res Function(_Tag) _then;
+
+  /// Create a copy of Tag
+  /// with the given fields replaced by the non-null parameter values.
+  @override
+  @pragma('vm:prefer-inline')
+  $Res call({
+    Object? id = null,
+    Object? name = null,
+    Object? createdAt = null,
+  }) {
+    return _then(_Tag(
+      id: null == id
+          ? _self.id
+          : id // ignore: cast_nullable_to_non_nullable
+              as String,
+      name: null == name
+          ? _self.name
+          : name // ignore: cast_nullable_to_non_nullable
+              as String,
+      createdAt: null == createdAt
+          ? _self.createdAt
+          : createdAt // ignore: cast_nullable_to_non_nullable
+              as int,
+    ));
+  }
+}
+
+// dart format on

--- a/lib/domain/entities/transaction.dart
+++ b/lib/domain/entities/transaction.dart
@@ -1,0 +1,120 @@
+// lib/domain/entities/transaction.dart
+//
+// Transaction domain entity.
+//
+// Represents an atomic financial event. Each transaction has two or more
+// corresponding Entry objects (DEB lines). Financial fields are immutable
+// after the transaction reaches status = posted; corrections produce a
+// reversal + correction pair (TC-001).
+//
+// Immutable financial fields: amountMinor, currencyCode, accountSourceId,
+// accountDestinationId, categoryId, subcategoryId.
+//
+// In-place editable fields: title, description, dateTime, payeeId.
+
+import 'package:freezed_annotation/freezed_annotation.dart';
+
+part 'transaction.freezed.dart';
+
+/// Ledger participation state of a transaction.
+enum TransactionStatus {
+  pending,
+  posted,
+  voided,
+}
+
+/// Role in the correction/reversal chain.
+enum TransactionPurpose {
+  user,
+  reversal,
+  correction,
+  system,
+}
+
+/// The financial direction of a transaction.
+enum TransactionType {
+  income,
+  expense,
+  transfer,
+}
+
+/// Immutable domain entity for an atomic financial event.
+@freezed
+abstract class Transaction with _$Transaction {
+  const factory Transaction({
+    /// UUID v4 stable identifier.
+    required String id,
+
+    /// Financial direction of the event.
+    required TransactionType type,
+
+    /// Ledger participation state (TC-001).
+    required TransactionStatus status,
+
+    /// Role within the correction/reversal chain (TC-001).
+    @Default(TransactionPurpose.user) TransactionPurpose purpose,
+
+    /// Business date as Unix epoch seconds.
+    required int dateTime,
+
+    /// Amount in minor units of [currencyCode].
+    required int amountMinor,
+
+    /// ISO 4217 code; derived from source account; immutable after posting.
+    required String currencyCode,
+
+    /// Exchange rate × 1,000,000 from [currencyCode] to
+    /// [homeCurrencyAtCapture]; null if currencies are equal (TC-029).
+    int? exchangeRateMicro,
+
+    /// Home currency at the time the rate was captured (TC-029).
+    String? homeCurrencyAtCapture,
+
+    /// Source account for expense/transfer; null for income.
+    String? accountSourceId,
+
+    /// Destination account for income/transfer; null for expense.
+    String? accountDestinationId,
+
+    /// Top-level category; null for transfer.
+    String? categoryId,
+
+    /// Optional subcategory; null for transfer.
+    String? subcategoryId,
+
+    /// Optional payee/merchant reference.
+    String? payeeId,
+
+    /// User-provided label; in-place editable.
+    String? title,
+
+    /// Long-form description; in-place editable.
+    String? description,
+
+    /// UUID shared by compound group members (e.g. transfer + fee); null for
+    /// non-compound transactions.
+    String? compoundGroupId,
+
+    /// Role within a compound group; null for non-compound.
+    String? compoundRole,
+
+    /// Link to the recurring template that generated this transaction.
+    String? parentTemplateId,
+
+    /// For purpose = correction or reversal: the ID of the transaction being
+    /// corrected/reversed.
+    String? correctsTransactionId,
+
+    /// True when a recurring child was edited/deleted outside normal scheduling.
+    @Default(false) bool isManuallyHandled,
+
+    /// System creation epoch.
+    required int createdAt,
+
+    /// Last-modified epoch.
+    required int updatedAt,
+
+    /// JSON escape hatch.
+    String? metadata,
+  }) = _Transaction;
+}

--- a/lib/domain/entities/transaction.freezed.dart
+++ b/lib/domain/entities/transaction.freezed.dart
@@ -1,0 +1,1053 @@
+// GENERATED CODE - DO NOT MODIFY BY HAND
+// coverage:ignore-file
+// ignore_for_file: type=lint
+// ignore_for_file: unused_element, deprecated_member_use, deprecated_member_use_from_same_package, use_function_type_syntax_for_parameters, unnecessary_const, avoid_init_to_null, invalid_override_different_default_values_named, prefer_expression_function_bodies, annotate_overrides, invalid_annotation_target, unnecessary_question_mark
+
+part of 'transaction.dart';
+
+// **************************************************************************
+// FreezedGenerator
+// **************************************************************************
+
+// dart format off
+T _$identity<T>(T value) => value;
+
+/// @nodoc
+mixin _$Transaction {
+  /// UUID v4 stable identifier.
+  String get id;
+
+  /// Financial direction of the event.
+  TransactionType get type;
+
+  /// Ledger participation state (TC-001).
+  TransactionStatus get status;
+
+  /// Role within the correction/reversal chain (TC-001).
+  TransactionPurpose get purpose;
+
+  /// Business date as Unix epoch seconds.
+  int get dateTime;
+
+  /// Amount in minor units of [currencyCode].
+  int get amountMinor;
+
+  /// ISO 4217 code; derived from source account; immutable after posting.
+  String get currencyCode;
+
+  /// Exchange rate × 1,000,000 from [currencyCode] to
+  /// [homeCurrencyAtCapture]; null if currencies are equal (TC-029).
+  int? get exchangeRateMicro;
+
+  /// Home currency at the time the rate was captured (TC-029).
+  String? get homeCurrencyAtCapture;
+
+  /// Source account for expense/transfer; null for income.
+  String? get accountSourceId;
+
+  /// Destination account for income/transfer; null for expense.
+  String? get accountDestinationId;
+
+  /// Top-level category; null for transfer.
+  String? get categoryId;
+
+  /// Optional subcategory; null for transfer.
+  String? get subcategoryId;
+
+  /// Optional payee/merchant reference.
+  String? get payeeId;
+
+  /// User-provided label; in-place editable.
+  String? get title;
+
+  /// Long-form description; in-place editable.
+  String? get description;
+
+  /// UUID shared by compound group members (e.g. transfer + fee); null for
+  /// non-compound transactions.
+  String? get compoundGroupId;
+
+  /// Role within a compound group; null for non-compound.
+  String? get compoundRole;
+
+  /// Link to the recurring template that generated this transaction.
+  String? get parentTemplateId;
+
+  /// For purpose = correction or reversal: the ID of the transaction being
+  /// corrected/reversed.
+  String? get correctsTransactionId;
+
+  /// True when a recurring child was edited/deleted outside normal scheduling.
+  bool get isManuallyHandled;
+
+  /// System creation epoch.
+  int get createdAt;
+
+  /// Last-modified epoch.
+  int get updatedAt;
+
+  /// JSON escape hatch.
+  String? get metadata;
+
+  /// Create a copy of Transaction
+  /// with the given fields replaced by the non-null parameter values.
+  @JsonKey(includeFromJson: false, includeToJson: false)
+  @pragma('vm:prefer-inline')
+  $TransactionCopyWith<Transaction> get copyWith =>
+      _$TransactionCopyWithImpl<Transaction>(this as Transaction, _$identity);
+
+  @override
+  bool operator ==(Object other) {
+    return identical(this, other) ||
+        (other.runtimeType == runtimeType &&
+            other is Transaction &&
+            (identical(other.id, id) || other.id == id) &&
+            (identical(other.type, type) || other.type == type) &&
+            (identical(other.status, status) || other.status == status) &&
+            (identical(other.purpose, purpose) || other.purpose == purpose) &&
+            (identical(other.dateTime, dateTime) ||
+                other.dateTime == dateTime) &&
+            (identical(other.amountMinor, amountMinor) ||
+                other.amountMinor == amountMinor) &&
+            (identical(other.currencyCode, currencyCode) ||
+                other.currencyCode == currencyCode) &&
+            (identical(other.exchangeRateMicro, exchangeRateMicro) ||
+                other.exchangeRateMicro == exchangeRateMicro) &&
+            (identical(other.homeCurrencyAtCapture, homeCurrencyAtCapture) ||
+                other.homeCurrencyAtCapture == homeCurrencyAtCapture) &&
+            (identical(other.accountSourceId, accountSourceId) ||
+                other.accountSourceId == accountSourceId) &&
+            (identical(other.accountDestinationId, accountDestinationId) ||
+                other.accountDestinationId == accountDestinationId) &&
+            (identical(other.categoryId, categoryId) ||
+                other.categoryId == categoryId) &&
+            (identical(other.subcategoryId, subcategoryId) ||
+                other.subcategoryId == subcategoryId) &&
+            (identical(other.payeeId, payeeId) || other.payeeId == payeeId) &&
+            (identical(other.title, title) || other.title == title) &&
+            (identical(other.description, description) ||
+                other.description == description) &&
+            (identical(other.compoundGroupId, compoundGroupId) ||
+                other.compoundGroupId == compoundGroupId) &&
+            (identical(other.compoundRole, compoundRole) ||
+                other.compoundRole == compoundRole) &&
+            (identical(other.parentTemplateId, parentTemplateId) ||
+                other.parentTemplateId == parentTemplateId) &&
+            (identical(other.correctsTransactionId, correctsTransactionId) ||
+                other.correctsTransactionId == correctsTransactionId) &&
+            (identical(other.isManuallyHandled, isManuallyHandled) ||
+                other.isManuallyHandled == isManuallyHandled) &&
+            (identical(other.createdAt, createdAt) ||
+                other.createdAt == createdAt) &&
+            (identical(other.updatedAt, updatedAt) ||
+                other.updatedAt == updatedAt) &&
+            (identical(other.metadata, metadata) ||
+                other.metadata == metadata));
+  }
+
+  @override
+  int get hashCode => Object.hashAll([
+        runtimeType,
+        id,
+        type,
+        status,
+        purpose,
+        dateTime,
+        amountMinor,
+        currencyCode,
+        exchangeRateMicro,
+        homeCurrencyAtCapture,
+        accountSourceId,
+        accountDestinationId,
+        categoryId,
+        subcategoryId,
+        payeeId,
+        title,
+        description,
+        compoundGroupId,
+        compoundRole,
+        parentTemplateId,
+        correctsTransactionId,
+        isManuallyHandled,
+        createdAt,
+        updatedAt,
+        metadata
+      ]);
+
+  @override
+  String toString() {
+    return 'Transaction(id: $id, type: $type, status: $status, purpose: $purpose, dateTime: $dateTime, amountMinor: $amountMinor, currencyCode: $currencyCode, exchangeRateMicro: $exchangeRateMicro, homeCurrencyAtCapture: $homeCurrencyAtCapture, accountSourceId: $accountSourceId, accountDestinationId: $accountDestinationId, categoryId: $categoryId, subcategoryId: $subcategoryId, payeeId: $payeeId, title: $title, description: $description, compoundGroupId: $compoundGroupId, compoundRole: $compoundRole, parentTemplateId: $parentTemplateId, correctsTransactionId: $correctsTransactionId, isManuallyHandled: $isManuallyHandled, createdAt: $createdAt, updatedAt: $updatedAt, metadata: $metadata)';
+  }
+}
+
+/// @nodoc
+abstract mixin class $TransactionCopyWith<$Res> {
+  factory $TransactionCopyWith(
+          Transaction value, $Res Function(Transaction) _then) =
+      _$TransactionCopyWithImpl;
+  @useResult
+  $Res call(
+      {String id,
+      TransactionType type,
+      TransactionStatus status,
+      TransactionPurpose purpose,
+      int dateTime,
+      int amountMinor,
+      String currencyCode,
+      int? exchangeRateMicro,
+      String? homeCurrencyAtCapture,
+      String? accountSourceId,
+      String? accountDestinationId,
+      String? categoryId,
+      String? subcategoryId,
+      String? payeeId,
+      String? title,
+      String? description,
+      String? compoundGroupId,
+      String? compoundRole,
+      String? parentTemplateId,
+      String? correctsTransactionId,
+      bool isManuallyHandled,
+      int createdAt,
+      int updatedAt,
+      String? metadata});
+}
+
+/// @nodoc
+class _$TransactionCopyWithImpl<$Res> implements $TransactionCopyWith<$Res> {
+  _$TransactionCopyWithImpl(this._self, this._then);
+
+  final Transaction _self;
+  final $Res Function(Transaction) _then;
+
+  /// Create a copy of Transaction
+  /// with the given fields replaced by the non-null parameter values.
+  @pragma('vm:prefer-inline')
+  @override
+  $Res call({
+    Object? id = null,
+    Object? type = null,
+    Object? status = null,
+    Object? purpose = null,
+    Object? dateTime = null,
+    Object? amountMinor = null,
+    Object? currencyCode = null,
+    Object? exchangeRateMicro = freezed,
+    Object? homeCurrencyAtCapture = freezed,
+    Object? accountSourceId = freezed,
+    Object? accountDestinationId = freezed,
+    Object? categoryId = freezed,
+    Object? subcategoryId = freezed,
+    Object? payeeId = freezed,
+    Object? title = freezed,
+    Object? description = freezed,
+    Object? compoundGroupId = freezed,
+    Object? compoundRole = freezed,
+    Object? parentTemplateId = freezed,
+    Object? correctsTransactionId = freezed,
+    Object? isManuallyHandled = null,
+    Object? createdAt = null,
+    Object? updatedAt = null,
+    Object? metadata = freezed,
+  }) {
+    return _then(_self.copyWith(
+      id: null == id
+          ? _self.id
+          : id // ignore: cast_nullable_to_non_nullable
+              as String,
+      type: null == type
+          ? _self.type
+          : type // ignore: cast_nullable_to_non_nullable
+              as TransactionType,
+      status: null == status
+          ? _self.status
+          : status // ignore: cast_nullable_to_non_nullable
+              as TransactionStatus,
+      purpose: null == purpose
+          ? _self.purpose
+          : purpose // ignore: cast_nullable_to_non_nullable
+              as TransactionPurpose,
+      dateTime: null == dateTime
+          ? _self.dateTime
+          : dateTime // ignore: cast_nullable_to_non_nullable
+              as int,
+      amountMinor: null == amountMinor
+          ? _self.amountMinor
+          : amountMinor // ignore: cast_nullable_to_non_nullable
+              as int,
+      currencyCode: null == currencyCode
+          ? _self.currencyCode
+          : currencyCode // ignore: cast_nullable_to_non_nullable
+              as String,
+      exchangeRateMicro: freezed == exchangeRateMicro
+          ? _self.exchangeRateMicro
+          : exchangeRateMicro // ignore: cast_nullable_to_non_nullable
+              as int?,
+      homeCurrencyAtCapture: freezed == homeCurrencyAtCapture
+          ? _self.homeCurrencyAtCapture
+          : homeCurrencyAtCapture // ignore: cast_nullable_to_non_nullable
+              as String?,
+      accountSourceId: freezed == accountSourceId
+          ? _self.accountSourceId
+          : accountSourceId // ignore: cast_nullable_to_non_nullable
+              as String?,
+      accountDestinationId: freezed == accountDestinationId
+          ? _self.accountDestinationId
+          : accountDestinationId // ignore: cast_nullable_to_non_nullable
+              as String?,
+      categoryId: freezed == categoryId
+          ? _self.categoryId
+          : categoryId // ignore: cast_nullable_to_non_nullable
+              as String?,
+      subcategoryId: freezed == subcategoryId
+          ? _self.subcategoryId
+          : subcategoryId // ignore: cast_nullable_to_non_nullable
+              as String?,
+      payeeId: freezed == payeeId
+          ? _self.payeeId
+          : payeeId // ignore: cast_nullable_to_non_nullable
+              as String?,
+      title: freezed == title
+          ? _self.title
+          : title // ignore: cast_nullable_to_non_nullable
+              as String?,
+      description: freezed == description
+          ? _self.description
+          : description // ignore: cast_nullable_to_non_nullable
+              as String?,
+      compoundGroupId: freezed == compoundGroupId
+          ? _self.compoundGroupId
+          : compoundGroupId // ignore: cast_nullable_to_non_nullable
+              as String?,
+      compoundRole: freezed == compoundRole
+          ? _self.compoundRole
+          : compoundRole // ignore: cast_nullable_to_non_nullable
+              as String?,
+      parentTemplateId: freezed == parentTemplateId
+          ? _self.parentTemplateId
+          : parentTemplateId // ignore: cast_nullable_to_non_nullable
+              as String?,
+      correctsTransactionId: freezed == correctsTransactionId
+          ? _self.correctsTransactionId
+          : correctsTransactionId // ignore: cast_nullable_to_non_nullable
+              as String?,
+      isManuallyHandled: null == isManuallyHandled
+          ? _self.isManuallyHandled
+          : isManuallyHandled // ignore: cast_nullable_to_non_nullable
+              as bool,
+      createdAt: null == createdAt
+          ? _self.createdAt
+          : createdAt // ignore: cast_nullable_to_non_nullable
+              as int,
+      updatedAt: null == updatedAt
+          ? _self.updatedAt
+          : updatedAt // ignore: cast_nullable_to_non_nullable
+              as int,
+      metadata: freezed == metadata
+          ? _self.metadata
+          : metadata // ignore: cast_nullable_to_non_nullable
+              as String?,
+    ));
+  }
+}
+
+/// Adds pattern-matching-related methods to [Transaction].
+extension TransactionPatterns on Transaction {
+  /// A variant of `map` that fallback to returning `orElse`.
+  ///
+  /// It is equivalent to doing:
+  /// ```dart
+  /// switch (sealedClass) {
+  ///   case final Subclass value:
+  ///     return ...;
+  ///   case _:
+  ///     return orElse();
+  /// }
+  /// ```
+
+  @optionalTypeArgs
+  TResult maybeMap<TResult extends Object?>(
+    TResult Function(_Transaction value)? $default, {
+    required TResult orElse(),
+  }) {
+    final _that = this;
+    switch (_that) {
+      case _Transaction() when $default != null:
+        return $default(_that);
+      case _:
+        return orElse();
+    }
+  }
+
+  /// A `switch`-like method, using callbacks.
+  ///
+  /// Callbacks receives the raw object, upcasted.
+  /// It is equivalent to doing:
+  /// ```dart
+  /// switch (sealedClass) {
+  ///   case final Subclass value:
+  ///     return ...;
+  ///   case final Subclass2 value:
+  ///     return ...;
+  /// }
+  /// ```
+
+  @optionalTypeArgs
+  TResult map<TResult extends Object?>(
+    TResult Function(_Transaction value) $default,
+  ) {
+    final _that = this;
+    switch (_that) {
+      case _Transaction():
+        return $default(_that);
+      case _:
+        throw StateError('Unexpected subclass');
+    }
+  }
+
+  /// A variant of `map` that fallback to returning `null`.
+  ///
+  /// It is equivalent to doing:
+  /// ```dart
+  /// switch (sealedClass) {
+  ///   case final Subclass value:
+  ///     return ...;
+  ///   case _:
+  ///     return null;
+  /// }
+  /// ```
+
+  @optionalTypeArgs
+  TResult? mapOrNull<TResult extends Object?>(
+    TResult? Function(_Transaction value)? $default,
+  ) {
+    final _that = this;
+    switch (_that) {
+      case _Transaction() when $default != null:
+        return $default(_that);
+      case _:
+        return null;
+    }
+  }
+
+  /// A variant of `when` that fallback to an `orElse` callback.
+  ///
+  /// It is equivalent to doing:
+  /// ```dart
+  /// switch (sealedClass) {
+  ///   case Subclass(:final field):
+  ///     return ...;
+  ///   case _:
+  ///     return orElse();
+  /// }
+  /// ```
+
+  @optionalTypeArgs
+  TResult maybeWhen<TResult extends Object?>(
+    TResult Function(
+            String id,
+            TransactionType type,
+            TransactionStatus status,
+            TransactionPurpose purpose,
+            int dateTime,
+            int amountMinor,
+            String currencyCode,
+            int? exchangeRateMicro,
+            String? homeCurrencyAtCapture,
+            String? accountSourceId,
+            String? accountDestinationId,
+            String? categoryId,
+            String? subcategoryId,
+            String? payeeId,
+            String? title,
+            String? description,
+            String? compoundGroupId,
+            String? compoundRole,
+            String? parentTemplateId,
+            String? correctsTransactionId,
+            bool isManuallyHandled,
+            int createdAt,
+            int updatedAt,
+            String? metadata)?
+        $default, {
+    required TResult orElse(),
+  }) {
+    final _that = this;
+    switch (_that) {
+      case _Transaction() when $default != null:
+        return $default(
+            _that.id,
+            _that.type,
+            _that.status,
+            _that.purpose,
+            _that.dateTime,
+            _that.amountMinor,
+            _that.currencyCode,
+            _that.exchangeRateMicro,
+            _that.homeCurrencyAtCapture,
+            _that.accountSourceId,
+            _that.accountDestinationId,
+            _that.categoryId,
+            _that.subcategoryId,
+            _that.payeeId,
+            _that.title,
+            _that.description,
+            _that.compoundGroupId,
+            _that.compoundRole,
+            _that.parentTemplateId,
+            _that.correctsTransactionId,
+            _that.isManuallyHandled,
+            _that.createdAt,
+            _that.updatedAt,
+            _that.metadata);
+      case _:
+        return orElse();
+    }
+  }
+
+  /// A `switch`-like method, using callbacks.
+  ///
+  /// As opposed to `map`, this offers destructuring.
+  /// It is equivalent to doing:
+  /// ```dart
+  /// switch (sealedClass) {
+  ///   case Subclass(:final field):
+  ///     return ...;
+  ///   case Subclass2(:final field2):
+  ///     return ...;
+  /// }
+  /// ```
+
+  @optionalTypeArgs
+  TResult when<TResult extends Object?>(
+    TResult Function(
+            String id,
+            TransactionType type,
+            TransactionStatus status,
+            TransactionPurpose purpose,
+            int dateTime,
+            int amountMinor,
+            String currencyCode,
+            int? exchangeRateMicro,
+            String? homeCurrencyAtCapture,
+            String? accountSourceId,
+            String? accountDestinationId,
+            String? categoryId,
+            String? subcategoryId,
+            String? payeeId,
+            String? title,
+            String? description,
+            String? compoundGroupId,
+            String? compoundRole,
+            String? parentTemplateId,
+            String? correctsTransactionId,
+            bool isManuallyHandled,
+            int createdAt,
+            int updatedAt,
+            String? metadata)
+        $default,
+  ) {
+    final _that = this;
+    switch (_that) {
+      case _Transaction():
+        return $default(
+            _that.id,
+            _that.type,
+            _that.status,
+            _that.purpose,
+            _that.dateTime,
+            _that.amountMinor,
+            _that.currencyCode,
+            _that.exchangeRateMicro,
+            _that.homeCurrencyAtCapture,
+            _that.accountSourceId,
+            _that.accountDestinationId,
+            _that.categoryId,
+            _that.subcategoryId,
+            _that.payeeId,
+            _that.title,
+            _that.description,
+            _that.compoundGroupId,
+            _that.compoundRole,
+            _that.parentTemplateId,
+            _that.correctsTransactionId,
+            _that.isManuallyHandled,
+            _that.createdAt,
+            _that.updatedAt,
+            _that.metadata);
+      case _:
+        throw StateError('Unexpected subclass');
+    }
+  }
+
+  /// A variant of `when` that fallback to returning `null`
+  ///
+  /// It is equivalent to doing:
+  /// ```dart
+  /// switch (sealedClass) {
+  ///   case Subclass(:final field):
+  ///     return ...;
+  ///   case _:
+  ///     return null;
+  /// }
+  /// ```
+
+  @optionalTypeArgs
+  TResult? whenOrNull<TResult extends Object?>(
+    TResult? Function(
+            String id,
+            TransactionType type,
+            TransactionStatus status,
+            TransactionPurpose purpose,
+            int dateTime,
+            int amountMinor,
+            String currencyCode,
+            int? exchangeRateMicro,
+            String? homeCurrencyAtCapture,
+            String? accountSourceId,
+            String? accountDestinationId,
+            String? categoryId,
+            String? subcategoryId,
+            String? payeeId,
+            String? title,
+            String? description,
+            String? compoundGroupId,
+            String? compoundRole,
+            String? parentTemplateId,
+            String? correctsTransactionId,
+            bool isManuallyHandled,
+            int createdAt,
+            int updatedAt,
+            String? metadata)?
+        $default,
+  ) {
+    final _that = this;
+    switch (_that) {
+      case _Transaction() when $default != null:
+        return $default(
+            _that.id,
+            _that.type,
+            _that.status,
+            _that.purpose,
+            _that.dateTime,
+            _that.amountMinor,
+            _that.currencyCode,
+            _that.exchangeRateMicro,
+            _that.homeCurrencyAtCapture,
+            _that.accountSourceId,
+            _that.accountDestinationId,
+            _that.categoryId,
+            _that.subcategoryId,
+            _that.payeeId,
+            _that.title,
+            _that.description,
+            _that.compoundGroupId,
+            _that.compoundRole,
+            _that.parentTemplateId,
+            _that.correctsTransactionId,
+            _that.isManuallyHandled,
+            _that.createdAt,
+            _that.updatedAt,
+            _that.metadata);
+      case _:
+        return null;
+    }
+  }
+}
+
+/// @nodoc
+
+class _Transaction implements Transaction {
+  const _Transaction(
+      {required this.id,
+      required this.type,
+      required this.status,
+      this.purpose = TransactionPurpose.user,
+      required this.dateTime,
+      required this.amountMinor,
+      required this.currencyCode,
+      this.exchangeRateMicro,
+      this.homeCurrencyAtCapture,
+      this.accountSourceId,
+      this.accountDestinationId,
+      this.categoryId,
+      this.subcategoryId,
+      this.payeeId,
+      this.title,
+      this.description,
+      this.compoundGroupId,
+      this.compoundRole,
+      this.parentTemplateId,
+      this.correctsTransactionId,
+      this.isManuallyHandled = false,
+      required this.createdAt,
+      required this.updatedAt,
+      this.metadata});
+
+  /// UUID v4 stable identifier.
+  @override
+  final String id;
+
+  /// Financial direction of the event.
+  @override
+  final TransactionType type;
+
+  /// Ledger participation state (TC-001).
+  @override
+  final TransactionStatus status;
+
+  /// Role within the correction/reversal chain (TC-001).
+  @override
+  @JsonKey()
+  final TransactionPurpose purpose;
+
+  /// Business date as Unix epoch seconds.
+  @override
+  final int dateTime;
+
+  /// Amount in minor units of [currencyCode].
+  @override
+  final int amountMinor;
+
+  /// ISO 4217 code; derived from source account; immutable after posting.
+  @override
+  final String currencyCode;
+
+  /// Exchange rate × 1,000,000 from [currencyCode] to
+  /// [homeCurrencyAtCapture]; null if currencies are equal (TC-029).
+  @override
+  final int? exchangeRateMicro;
+
+  /// Home currency at the time the rate was captured (TC-029).
+  @override
+  final String? homeCurrencyAtCapture;
+
+  /// Source account for expense/transfer; null for income.
+  @override
+  final String? accountSourceId;
+
+  /// Destination account for income/transfer; null for expense.
+  @override
+  final String? accountDestinationId;
+
+  /// Top-level category; null for transfer.
+  @override
+  final String? categoryId;
+
+  /// Optional subcategory; null for transfer.
+  @override
+  final String? subcategoryId;
+
+  /// Optional payee/merchant reference.
+  @override
+  final String? payeeId;
+
+  /// User-provided label; in-place editable.
+  @override
+  final String? title;
+
+  /// Long-form description; in-place editable.
+  @override
+  final String? description;
+
+  /// UUID shared by compound group members (e.g. transfer + fee); null for
+  /// non-compound transactions.
+  @override
+  final String? compoundGroupId;
+
+  /// Role within a compound group; null for non-compound.
+  @override
+  final String? compoundRole;
+
+  /// Link to the recurring template that generated this transaction.
+  @override
+  final String? parentTemplateId;
+
+  /// For purpose = correction or reversal: the ID of the transaction being
+  /// corrected/reversed.
+  @override
+  final String? correctsTransactionId;
+
+  /// True when a recurring child was edited/deleted outside normal scheduling.
+  @override
+  @JsonKey()
+  final bool isManuallyHandled;
+
+  /// System creation epoch.
+  @override
+  final int createdAt;
+
+  /// Last-modified epoch.
+  @override
+  final int updatedAt;
+
+  /// JSON escape hatch.
+  @override
+  final String? metadata;
+
+  /// Create a copy of Transaction
+  /// with the given fields replaced by the non-null parameter values.
+  @override
+  @JsonKey(includeFromJson: false, includeToJson: false)
+  @pragma('vm:prefer-inline')
+  _$TransactionCopyWith<_Transaction> get copyWith =>
+      __$TransactionCopyWithImpl<_Transaction>(this, _$identity);
+
+  @override
+  bool operator ==(Object other) {
+    return identical(this, other) ||
+        (other.runtimeType == runtimeType &&
+            other is _Transaction &&
+            (identical(other.id, id) || other.id == id) &&
+            (identical(other.type, type) || other.type == type) &&
+            (identical(other.status, status) || other.status == status) &&
+            (identical(other.purpose, purpose) || other.purpose == purpose) &&
+            (identical(other.dateTime, dateTime) ||
+                other.dateTime == dateTime) &&
+            (identical(other.amountMinor, amountMinor) ||
+                other.amountMinor == amountMinor) &&
+            (identical(other.currencyCode, currencyCode) ||
+                other.currencyCode == currencyCode) &&
+            (identical(other.exchangeRateMicro, exchangeRateMicro) ||
+                other.exchangeRateMicro == exchangeRateMicro) &&
+            (identical(other.homeCurrencyAtCapture, homeCurrencyAtCapture) ||
+                other.homeCurrencyAtCapture == homeCurrencyAtCapture) &&
+            (identical(other.accountSourceId, accountSourceId) ||
+                other.accountSourceId == accountSourceId) &&
+            (identical(other.accountDestinationId, accountDestinationId) ||
+                other.accountDestinationId == accountDestinationId) &&
+            (identical(other.categoryId, categoryId) ||
+                other.categoryId == categoryId) &&
+            (identical(other.subcategoryId, subcategoryId) ||
+                other.subcategoryId == subcategoryId) &&
+            (identical(other.payeeId, payeeId) || other.payeeId == payeeId) &&
+            (identical(other.title, title) || other.title == title) &&
+            (identical(other.description, description) ||
+                other.description == description) &&
+            (identical(other.compoundGroupId, compoundGroupId) ||
+                other.compoundGroupId == compoundGroupId) &&
+            (identical(other.compoundRole, compoundRole) ||
+                other.compoundRole == compoundRole) &&
+            (identical(other.parentTemplateId, parentTemplateId) ||
+                other.parentTemplateId == parentTemplateId) &&
+            (identical(other.correctsTransactionId, correctsTransactionId) ||
+                other.correctsTransactionId == correctsTransactionId) &&
+            (identical(other.isManuallyHandled, isManuallyHandled) ||
+                other.isManuallyHandled == isManuallyHandled) &&
+            (identical(other.createdAt, createdAt) ||
+                other.createdAt == createdAt) &&
+            (identical(other.updatedAt, updatedAt) ||
+                other.updatedAt == updatedAt) &&
+            (identical(other.metadata, metadata) ||
+                other.metadata == metadata));
+  }
+
+  @override
+  int get hashCode => Object.hashAll([
+        runtimeType,
+        id,
+        type,
+        status,
+        purpose,
+        dateTime,
+        amountMinor,
+        currencyCode,
+        exchangeRateMicro,
+        homeCurrencyAtCapture,
+        accountSourceId,
+        accountDestinationId,
+        categoryId,
+        subcategoryId,
+        payeeId,
+        title,
+        description,
+        compoundGroupId,
+        compoundRole,
+        parentTemplateId,
+        correctsTransactionId,
+        isManuallyHandled,
+        createdAt,
+        updatedAt,
+        metadata
+      ]);
+
+  @override
+  String toString() {
+    return 'Transaction(id: $id, type: $type, status: $status, purpose: $purpose, dateTime: $dateTime, amountMinor: $amountMinor, currencyCode: $currencyCode, exchangeRateMicro: $exchangeRateMicro, homeCurrencyAtCapture: $homeCurrencyAtCapture, accountSourceId: $accountSourceId, accountDestinationId: $accountDestinationId, categoryId: $categoryId, subcategoryId: $subcategoryId, payeeId: $payeeId, title: $title, description: $description, compoundGroupId: $compoundGroupId, compoundRole: $compoundRole, parentTemplateId: $parentTemplateId, correctsTransactionId: $correctsTransactionId, isManuallyHandled: $isManuallyHandled, createdAt: $createdAt, updatedAt: $updatedAt, metadata: $metadata)';
+  }
+}
+
+/// @nodoc
+abstract mixin class _$TransactionCopyWith<$Res>
+    implements $TransactionCopyWith<$Res> {
+  factory _$TransactionCopyWith(
+          _Transaction value, $Res Function(_Transaction) _then) =
+      __$TransactionCopyWithImpl;
+  @override
+  @useResult
+  $Res call(
+      {String id,
+      TransactionType type,
+      TransactionStatus status,
+      TransactionPurpose purpose,
+      int dateTime,
+      int amountMinor,
+      String currencyCode,
+      int? exchangeRateMicro,
+      String? homeCurrencyAtCapture,
+      String? accountSourceId,
+      String? accountDestinationId,
+      String? categoryId,
+      String? subcategoryId,
+      String? payeeId,
+      String? title,
+      String? description,
+      String? compoundGroupId,
+      String? compoundRole,
+      String? parentTemplateId,
+      String? correctsTransactionId,
+      bool isManuallyHandled,
+      int createdAt,
+      int updatedAt,
+      String? metadata});
+}
+
+/// @nodoc
+class __$TransactionCopyWithImpl<$Res> implements _$TransactionCopyWith<$Res> {
+  __$TransactionCopyWithImpl(this._self, this._then);
+
+  final _Transaction _self;
+  final $Res Function(_Transaction) _then;
+
+  /// Create a copy of Transaction
+  /// with the given fields replaced by the non-null parameter values.
+  @override
+  @pragma('vm:prefer-inline')
+  $Res call({
+    Object? id = null,
+    Object? type = null,
+    Object? status = null,
+    Object? purpose = null,
+    Object? dateTime = null,
+    Object? amountMinor = null,
+    Object? currencyCode = null,
+    Object? exchangeRateMicro = freezed,
+    Object? homeCurrencyAtCapture = freezed,
+    Object? accountSourceId = freezed,
+    Object? accountDestinationId = freezed,
+    Object? categoryId = freezed,
+    Object? subcategoryId = freezed,
+    Object? payeeId = freezed,
+    Object? title = freezed,
+    Object? description = freezed,
+    Object? compoundGroupId = freezed,
+    Object? compoundRole = freezed,
+    Object? parentTemplateId = freezed,
+    Object? correctsTransactionId = freezed,
+    Object? isManuallyHandled = null,
+    Object? createdAt = null,
+    Object? updatedAt = null,
+    Object? metadata = freezed,
+  }) {
+    return _then(_Transaction(
+      id: null == id
+          ? _self.id
+          : id // ignore: cast_nullable_to_non_nullable
+              as String,
+      type: null == type
+          ? _self.type
+          : type // ignore: cast_nullable_to_non_nullable
+              as TransactionType,
+      status: null == status
+          ? _self.status
+          : status // ignore: cast_nullable_to_non_nullable
+              as TransactionStatus,
+      purpose: null == purpose
+          ? _self.purpose
+          : purpose // ignore: cast_nullable_to_non_nullable
+              as TransactionPurpose,
+      dateTime: null == dateTime
+          ? _self.dateTime
+          : dateTime // ignore: cast_nullable_to_non_nullable
+              as int,
+      amountMinor: null == amountMinor
+          ? _self.amountMinor
+          : amountMinor // ignore: cast_nullable_to_non_nullable
+              as int,
+      currencyCode: null == currencyCode
+          ? _self.currencyCode
+          : currencyCode // ignore: cast_nullable_to_non_nullable
+              as String,
+      exchangeRateMicro: freezed == exchangeRateMicro
+          ? _self.exchangeRateMicro
+          : exchangeRateMicro // ignore: cast_nullable_to_non_nullable
+              as int?,
+      homeCurrencyAtCapture: freezed == homeCurrencyAtCapture
+          ? _self.homeCurrencyAtCapture
+          : homeCurrencyAtCapture // ignore: cast_nullable_to_non_nullable
+              as String?,
+      accountSourceId: freezed == accountSourceId
+          ? _self.accountSourceId
+          : accountSourceId // ignore: cast_nullable_to_non_nullable
+              as String?,
+      accountDestinationId: freezed == accountDestinationId
+          ? _self.accountDestinationId
+          : accountDestinationId // ignore: cast_nullable_to_non_nullable
+              as String?,
+      categoryId: freezed == categoryId
+          ? _self.categoryId
+          : categoryId // ignore: cast_nullable_to_non_nullable
+              as String?,
+      subcategoryId: freezed == subcategoryId
+          ? _self.subcategoryId
+          : subcategoryId // ignore: cast_nullable_to_non_nullable
+              as String?,
+      payeeId: freezed == payeeId
+          ? _self.payeeId
+          : payeeId // ignore: cast_nullable_to_non_nullable
+              as String?,
+      title: freezed == title
+          ? _self.title
+          : title // ignore: cast_nullable_to_non_nullable
+              as String?,
+      description: freezed == description
+          ? _self.description
+          : description // ignore: cast_nullable_to_non_nullable
+              as String?,
+      compoundGroupId: freezed == compoundGroupId
+          ? _self.compoundGroupId
+          : compoundGroupId // ignore: cast_nullable_to_non_nullable
+              as String?,
+      compoundRole: freezed == compoundRole
+          ? _self.compoundRole
+          : compoundRole // ignore: cast_nullable_to_non_nullable
+              as String?,
+      parentTemplateId: freezed == parentTemplateId
+          ? _self.parentTemplateId
+          : parentTemplateId // ignore: cast_nullable_to_non_nullable
+              as String?,
+      correctsTransactionId: freezed == correctsTransactionId
+          ? _self.correctsTransactionId
+          : correctsTransactionId // ignore: cast_nullable_to_non_nullable
+              as String?,
+      isManuallyHandled: null == isManuallyHandled
+          ? _self.isManuallyHandled
+          : isManuallyHandled // ignore: cast_nullable_to_non_nullable
+              as bool,
+      createdAt: null == createdAt
+          ? _self.createdAt
+          : createdAt // ignore: cast_nullable_to_non_nullable
+              as int,
+      updatedAt: null == updatedAt
+          ? _self.updatedAt
+          : updatedAt // ignore: cast_nullable_to_non_nullable
+              as int,
+      metadata: freezed == metadata
+          ? _self.metadata
+          : metadata // ignore: cast_nullable_to_non_nullable
+              as String?,
+    ));
+  }
+}
+
+// dart format on

--- a/lib/domain/repositories/i_account_repository.dart
+++ b/lib/domain/repositories/i_account_repository.dart
@@ -1,0 +1,37 @@
+// lib/domain/repositories/i_account_repository.dart
+//
+// Abstract repository interface for the Account aggregate.
+//
+// All write operations return Future<Result<T>> — never throw across the
+// layer boundary (SDS §2.9.3).
+// All read-only queries that must stay in sync with the database return
+// Stream<T> and do NOT use Result<T> (errors surface via StreamController).
+
+import 'package:variance/domain/core/result.dart';
+import 'package:variance/domain/entities/account.dart';
+import 'package:variance/domain/entities/money.dart';
+
+/// Contract for all Account data-access operations.
+abstract interface class IAccountRepository {
+  /// Watches the full list of non-system, non-deleted accounts.
+  Stream<List<Account>> watchAll();
+
+  /// Watches a single account by its UUID.
+  ///
+  /// Emits null if the account does not exist or has been soft-deleted.
+  Stream<Account?> watchById(String id);
+
+  /// Persists a new account.
+  Future<Result<Account>> create(Account account);
+
+  /// Updates an existing account (non-financial fields only after first post).
+  Future<Result<Account>> update(Account account);
+
+  /// Soft-deletes the account with [id].
+  Future<Result<void>> softDelete(String id);
+
+  /// Watches the computed balance of [id] denominated in [currencyCode].
+  ///
+  /// Balance = Σ debit entries − Σ credit entries for all posted transactions.
+  Stream<Money> watchBalance(String id, String currencyCode);
+}

--- a/lib/domain/repositories/i_app_settings_repository.dart
+++ b/lib/domain/repositories/i_app_settings_repository.dart
@@ -1,0 +1,50 @@
+// lib/domain/repositories/i_app_settings_repository.dart
+//
+// Abstract repository interface for the AppSettings aggregate.
+
+import 'package:variance/domain/core/result.dart';
+import 'package:variance/domain/entities/app_settings.dart';
+
+/// Partial patch object for AppSettings updates.
+///
+/// Only non-null fields are applied; null means "leave unchanged".
+class AppSettingsPatch {
+  const AppSettingsPatch({
+    this.homeCurrency,
+    this.theme,
+    this.colorSchemeMode,
+    this.colorSeed,
+    this.animationsEnabled,
+    this.weekStart,
+    this.percentagePrecision,
+    this.descriptionMaxLength,
+    this.backButtonBehaviour,
+    this.lockTimeoutSeconds,
+    this.displayName,
+    this.onboardingComplete,
+    this.lastExchangeRateFetch,
+  });
+
+  final String? homeCurrency;
+  final AppTheme? theme;
+  final ColorSchemeMode? colorSchemeMode;
+  final String? colorSeed;
+  final bool? animationsEnabled;
+  final WeekStart? weekStart;
+  final int? percentagePrecision;
+  final int? descriptionMaxLength;
+  final BackButtonBehaviour? backButtonBehaviour;
+  final int? lockTimeoutSeconds;
+  final String? displayName;
+  final bool? onboardingComplete;
+  final int? lastExchangeRateFetch;
+}
+
+/// Contract for all AppSettings data-access operations.
+abstract interface class IAppSettingsRepository {
+  /// Watches the live settings object; emits on every change.
+  Stream<AppSettings> watch();
+
+  /// Applies a partial patch to the settings.
+  Future<Result<void>> update(AppSettingsPatch patch);
+}

--- a/lib/domain/repositories/i_budget_repository.dart
+++ b/lib/domain/repositories/i_budget_repository.dart
@@ -1,0 +1,28 @@
+// lib/domain/repositories/i_budget_repository.dart
+//
+// Abstract repository interface for the Budget aggregate.
+
+import 'package:variance/domain/core/result.dart';
+import 'package:variance/domain/entities/budget.dart';
+import 'package:variance/domain/entities/budget_period.dart';
+
+/// Contract for all Budget data-access operations.
+abstract interface class IBudgetRepository {
+  /// Watches all active budgets.
+  Stream<List<Budget>> watchAll();
+
+  /// Watches a single budget by UUID.
+  Stream<Budget?> watchById(String id);
+
+  /// Persists a new budget.
+  Future<Result<Budget>> create(Budget budget);
+
+  /// Updates a budget's mutable fields.
+  Future<Result<Budget>> update(Budget budget);
+
+  /// Deactivates a budget (sets isActive = false).
+  Future<Result<void>> deactivate(String id);
+
+  /// Watches all period records for a given budget.
+  Stream<List<BudgetPeriod>> watchPeriodsForBudget(String budgetId);
+}

--- a/lib/domain/repositories/i_category_repository.dart
+++ b/lib/domain/repositories/i_category_repository.dart
@@ -1,0 +1,24 @@
+// lib/domain/repositories/i_category_repository.dart
+//
+// Abstract repository interface for the Category aggregate.
+
+import 'package:variance/domain/core/result.dart';
+import 'package:variance/domain/entities/category.dart';
+
+/// Contract for all Category data-access operations.
+abstract interface class ICategoryRepository {
+  /// Watches all non-deleted categories (both income and expense trees).
+  Stream<List<Category>> watchAll();
+
+  /// Persists a new category.
+  Future<Result<Category>> create(Category category);
+
+  /// Updates an existing category.
+  Future<Result<Category>> update(Category category);
+
+  /// Soft-deletes the category with [id].
+  ///
+  /// [replacementId] — if provided, existing transactions referencing [id]
+  /// are re-assigned to [replacementId] before deletion.
+  Future<Result<void>> softDelete(String id, {String? replacementId});
+}

--- a/lib/domain/repositories/i_currency_repository.dart
+++ b/lib/domain/repositories/i_currency_repository.dart
@@ -1,0 +1,24 @@
+// lib/domain/repositories/i_currency_repository.dart
+//
+// Abstract repository interface for the Currency aggregate.
+
+import 'package:variance/domain/core/result.dart';
+import 'package:variance/domain/entities/currency.dart';
+
+/// Contract for all Currency data-access operations.
+abstract interface class ICurrencyRepository {
+  /// Watches the full ISO 4217 currency list (~180 currencies).
+  Stream<List<Currency>> watchAll();
+
+  /// Watches only currencies that the user has enabled.
+  Stream<List<Currency>> watchEnabled();
+
+  /// Sets the home (base) currency for the app.
+  Future<Result<void>> setHomeCurrency(String code);
+
+  /// Marks [code] as enabled for use in transactions.
+  Future<Result<void>> enableCurrency(String code);
+
+  /// Marks [code] as disabled.
+  Future<Result<void>> disableCurrency(String code);
+}

--- a/lib/domain/repositories/i_draft_repository.dart
+++ b/lib/domain/repositories/i_draft_repository.dart
@@ -1,0 +1,20 @@
+// lib/domain/repositories/i_draft_repository.dart
+//
+// Abstract repository interface for the Draft aggregate.
+
+import 'package:variance/domain/core/result.dart';
+import 'package:variance/domain/entities/draft.dart';
+
+/// Contract for Draft (auto-saved form state) data-access operations.
+abstract interface class IDraftRepository {
+  /// Watches all drafts, ordered by creation epoch (oldest first).
+  ///
+  /// Max 5 rows enforced by the data layer (FIFO eviction).
+  Stream<List<Draft>> watchAll();
+
+  /// Creates or replaces a draft for the given [draft.id].
+  Future<Result<Draft>> upsert(Draft draft);
+
+  /// Permanently deletes the draft with [id].
+  Future<Result<void>> delete(String id);
+}

--- a/lib/domain/repositories/i_entry_repository.dart
+++ b/lib/domain/repositories/i_entry_repository.dart
@@ -1,0 +1,24 @@
+// lib/domain/repositories/i_entry_repository.dart
+//
+// Abstract repository interface for the Entry aggregate.
+//
+// This is an internal repository — called only by the LedgerEngine inside a
+// database transaction. It is not exposed to use cases directly.
+
+import 'package:variance/domain/core/result.dart';
+import 'package:variance/domain/entities/entry.dart';
+
+/// Contract for raw DEB ledger-line access.
+///
+/// Not intended for direct use by feature use cases; the LedgerEngine
+/// orchestrates entry writes as part of transaction creation/correction.
+abstract interface class IEntryRepository {
+  /// Watches all entries for an account, ordered by creation epoch.
+  Stream<List<Entry>> watchByAccount(String accountId);
+
+  /// Inserts a debit/credit pair atomically.
+  ///
+  /// Both entries must belong to the same transaction and satisfy
+  /// debit.amountMinor == credit.amountMinor (enforced by LedgerEngine).
+  Future<Result<void>> insertPair(Entry debit, Entry credit);
+}

--- a/lib/domain/repositories/i_exchange_rate_repository.dart
+++ b/lib/domain/repositories/i_exchange_rate_repository.dart
@@ -1,0 +1,24 @@
+// lib/domain/repositories/i_exchange_rate_repository.dart
+//
+// Abstract repository interface for the ExchangeRate aggregate.
+
+import 'package:decimal/decimal.dart';
+import 'package:variance/domain/core/result.dart';
+
+/// Contract for all ExchangeRate data-access and fetch operations.
+abstract interface class IExchangeRateRepository {
+  /// Returns the exchange rate for [from] → [to] on [date] (ISO 8601 string).
+  ///
+  /// Cache-first: reads the cached value if available. Returns a staleness
+  /// warning in the failure message if the cached rate is older than 14 days.
+  Future<Result<Decimal>> getRate(String from, String to, String date);
+
+  /// Synchronously returns the cached rate for [from] → [to] on [date].
+  ///
+  /// Returns Err(NotFoundFailure) if the pair is not in the local cache.
+  Result<Decimal> getCachedRate(String from, String to, String date);
+
+  /// Fetches the latest rates from the remote API and upserts them into the
+  /// local cache. Called by WorkManager on a background schedule.
+  Future<Result<void>> fetchAndCache();
+}

--- a/lib/domain/repositories/i_installment_occurrence_repository.dart
+++ b/lib/domain/repositories/i_installment_occurrence_repository.dart
@@ -1,0 +1,15 @@
+// lib/domain/repositories/i_installment_occurrence_repository.dart
+//
+// Abstract repository interface for the InstallmentOccurrence aggregate.
+
+import 'package:variance/domain/core/result.dart';
+import 'package:variance/domain/entities/installment_occurrence.dart';
+
+/// Contract for InstallmentOccurrence data-access operations.
+abstract interface class IInstallmentOccurrenceRepository {
+  /// Watches all occurrences for an installment plan, ordered by sequence.
+  Stream<List<InstallmentOccurrence>> watchByPlan(String planId);
+
+  /// Marks a pending occurrence as posted and records [transactionId].
+  Future<Result<void>> markPosted(String id, String transactionId);
+}

--- a/lib/domain/repositories/i_installment_plan_repository.dart
+++ b/lib/domain/repositories/i_installment_plan_repository.dart
@@ -1,0 +1,24 @@
+// lib/domain/repositories/i_installment_plan_repository.dart
+//
+// Abstract repository interface for the InstallmentPlan aggregate.
+
+import 'package:variance/domain/core/result.dart';
+import 'package:variance/domain/entities/installment_plan.dart';
+
+/// Contract for all InstallmentPlan data-access operations.
+abstract interface class IInstallmentPlanRepository {
+  /// Watches all installment plans (non-deleted templates with isInstallment).
+  Stream<List<InstallmentPlan>> watchAll();
+
+  /// Watches a single installment plan by its template UUID.
+  Stream<InstallmentPlan?> watchById(String id);
+
+  /// Creates a new installment plan (together with its template).
+  Future<Result<InstallmentPlan>> create(InstallmentPlan plan);
+
+  /// Updates mutable plan fields (e.g. numberOfInstallments for future items).
+  Future<Result<InstallmentPlan>> update(InstallmentPlan plan);
+
+  /// Closes an installment plan early; cancels all pending occurrences.
+  Future<Result<void>> closeEarly(String id);
+}

--- a/lib/domain/repositories/i_payee_repository.dart
+++ b/lib/domain/repositories/i_payee_repository.dart
@@ -1,0 +1,21 @@
+// lib/domain/repositories/i_payee_repository.dart
+//
+// Abstract repository interface for the Payee aggregate.
+
+import 'package:variance/domain/core/result.dart';
+import 'package:variance/domain/entities/payee.dart';
+
+/// Contract for all Payee data-access operations.
+abstract interface class IPayeeRepository {
+  /// Watches all non-deleted payees.
+  Stream<List<Payee>> watchAll();
+
+  /// Creates a new payee with [name].
+  Future<Result<Payee>> create(String name);
+
+  /// Renames the payee with [id].
+  Future<Result<Payee>> rename(String id, String name);
+
+  /// Soft-deletes the payee with [id].
+  Future<Result<void>> softDelete(String id);
+}

--- a/lib/domain/repositories/i_recurring_template_repository.dart
+++ b/lib/domain/repositories/i_recurring_template_repository.dart
@@ -1,0 +1,33 @@
+// lib/domain/repositories/i_recurring_template_repository.dart
+//
+// Abstract repository interface for the RecurringTemplate aggregate.
+
+import 'package:variance/domain/core/result.dart';
+import 'package:variance/domain/entities/recurring_template.dart';
+
+/// Contract for all RecurringTemplate data-access operations.
+abstract interface class IRecurringTemplateRepository {
+  /// Watches all non-deleted templates (both recurring and installment).
+  Stream<List<RecurringTemplate>> watchAll();
+
+  /// Watches a single template by UUID.
+  Stream<RecurringTemplate?> watchById(String id);
+
+  /// Persists a new template.
+  Future<Result<RecurringTemplate>> create(RecurringTemplate template);
+
+  /// Updates an editable template (amount, accounts, category, title, etc.).
+  Future<Result<RecurringTemplate>> update(RecurringTemplate template);
+
+  /// Transitions a template to status = paused.
+  Future<Result<void>> pause(String id);
+
+  /// Transitions a paused template back to status = active.
+  Future<Result<void>> resume(String id);
+
+  /// Soft-deletes a template; cancels all pending occurrences.
+  Future<Result<void>> softDelete(String id);
+
+  /// Returns all active templates whose next occurrence is on or before [asOf].
+  Future<Result<List<RecurringTemplate>>> getDue(DateTime asOf);
+}

--- a/lib/domain/repositories/i_scheduled_occurrence_repository.dart
+++ b/lib/domain/repositories/i_scheduled_occurrence_repository.dart
@@ -1,0 +1,15 @@
+// lib/domain/repositories/i_scheduled_occurrence_repository.dart
+//
+// Abstract repository interface for the ScheduledOccurrence aggregate.
+
+import 'package:variance/domain/core/result.dart';
+
+/// Contract for ScheduledOccurrence status-update operations.
+abstract interface class IScheduledOccurrenceRepository {
+  /// Marks a pending occurrence as posted and records the resulting
+  /// [transactionId].
+  Future<Result<void>> markPosted(String id, String transactionId);
+
+  /// Marks a pending occurrence as skipped (manually handled or pause-skipped).
+  Future<Result<void>> markSkipped(String id);
+}

--- a/lib/domain/repositories/i_tag_repository.dart
+++ b/lib/domain/repositories/i_tag_repository.dart
@@ -1,0 +1,21 @@
+// lib/domain/repositories/i_tag_repository.dart
+//
+// Abstract repository interface for the Tag aggregate.
+
+import 'package:variance/domain/core/result.dart';
+import 'package:variance/domain/entities/tag.dart';
+
+/// Contract for all Tag data-access operations.
+abstract interface class ITagRepository {
+  /// Watches all tags.
+  Stream<List<Tag>> watchAll();
+
+  /// Creates a new tag with [name].
+  Future<Result<Tag>> create(String name);
+
+  /// Renames the tag with [id].
+  Future<Result<Tag>> rename(String id, String name);
+
+  /// Soft-deletes the tag with [id].
+  Future<Result<void>> softDelete(String id);
+}

--- a/lib/domain/repositories/i_transaction_repository.dart
+++ b/lib/domain/repositories/i_transaction_repository.dart
@@ -1,0 +1,82 @@
+// lib/domain/repositories/i_transaction_repository.dart
+//
+// Abstract repository interface for the Transaction aggregate.
+//
+// Financial edits use correctFinancial (reversal + correction pair in a single
+// DB transaction). Non-financial in-place edits use updateNonFinancial.
+// Void and bulk-void mark transactions as voided without a correction chain.
+
+import 'package:variance/domain/core/result.dart';
+import 'package:variance/domain/entities/transaction.dart';
+
+/// Patch object for non-financial in-place edits.
+///
+/// Only the fields present (non-null) are applied.
+class TransactionNonFinancialPatch {
+  const TransactionNonFinancialPatch({
+    this.title,
+    this.description,
+    this.dateTime,
+    this.payeeId,
+  });
+
+  final String? title;
+  final String? description;
+  final int? dateTime;
+  final String? payeeId;
+}
+
+/// Optional filters for transaction list queries.
+class TransactionFilters {
+  const TransactionFilters({
+    this.accountId,
+    this.categoryId,
+    this.type,
+  });
+
+  final String? accountId;
+  final String? categoryId;
+  final TransactionType? type;
+}
+
+/// Contract for all Transaction data-access operations.
+abstract interface class ITransactionRepository {
+  /// Watches all non-voided, non-reversal transactions for a given month.
+  ///
+  /// [year] and [month] use calendar values (e.g. 2025, 5 for May 2025).
+  Stream<List<Transaction>> watchByMonth(
+    int year,
+    int month, {
+    TransactionFilters? filters,
+  });
+
+  /// Watches a single transaction by UUID.
+  Stream<Transaction?> watchById(String id);
+
+  /// Creates a new transaction from [draft] (a fully validated Transaction
+  /// value object in status=pending or posted).
+  Future<Result<Transaction>> create(Transaction draft);
+
+  /// Corrects financial fields via a reversal + correction pair, both
+  /// wrapped in a single database transaction.
+  Future<Result<Transaction>> correctFinancial(String id, Transaction draft);
+
+  /// Updates non-financial fields (title, description, dateTime, payeeId)
+  /// in-place; does not create a ledger entry pair.
+  Future<Result<Transaction>> updateNonFinancial(
+    String id,
+    TransactionNonFinancialPatch patch,
+  );
+
+  /// Voids a single transaction.
+  Future<Result<void>> void$(String id);
+
+  /// Voids multiple transactions atomically.
+  Future<Result<void>> bulkVoid(List<String> ids);
+
+  /// Full-text search with optional filters.
+  Future<Result<List<Transaction>>> search(
+    String query, {
+    TransactionFilters? filters,
+  });
+}

--- a/lib/domain/usecases/account/create_account_use_case.dart
+++ b/lib/domain/usecases/account/create_account_use_case.dart
@@ -1,0 +1,20 @@
+// lib/domain/usecases/account/create_account_use_case.dart
+//
+// Use case: create a new financial account.
+
+import 'package:variance/domain/core/result.dart';
+import 'package:variance/domain/entities/account.dart';
+import 'package:variance/domain/repositories/i_account_repository.dart';
+
+/// Creates a new account and persists it.
+class CreateAccountUseCase {
+  const CreateAccountUseCase(this._repository);
+
+  // ignore: unused_field
+  final IAccountRepository _repository;
+
+  /// Executes the use case.
+  Future<Result<Account>> call(Account account) {
+    throw UnimplementedError('CreateAccountUseCase.call is not implemented');
+  }
+}

--- a/lib/domain/usecases/account/delete_account_use_case.dart
+++ b/lib/domain/usecases/account/delete_account_use_case.dart
@@ -1,0 +1,21 @@
+// lib/domain/usecases/account/delete_account_use_case.dart
+//
+// Use case: soft-delete an account.
+
+import 'package:variance/domain/core/result.dart';
+import 'package:variance/domain/repositories/i_account_repository.dart';
+
+/// Soft-deletes the account identified by [id].
+///
+/// Protected accounts (EQ, BAI/BAE) return a BusinessRuleFailure.
+class DeleteAccountUseCase {
+  const DeleteAccountUseCase(this._repository);
+
+  // ignore: unused_field
+  final IAccountRepository _repository;
+
+  /// Executes the use case.
+  Future<Result<void>> call(String id) {
+    throw UnimplementedError('DeleteAccountUseCase.call is not implemented');
+  }
+}

--- a/lib/domain/usecases/account/get_account_balance_use_case.dart
+++ b/lib/domain/usecases/account/get_account_balance_use_case.dart
@@ -1,0 +1,22 @@
+// lib/domain/usecases/account/get_account_balance_use_case.dart
+//
+// Use case: watch the live balance of an account.
+
+import 'package:variance/domain/entities/money.dart';
+import 'package:variance/domain/repositories/i_account_repository.dart';
+
+/// Returns a reactive stream of the computed balance for account [id],
+/// denominated in [currencyCode].
+class GetAccountBalanceUseCase {
+  const GetAccountBalanceUseCase(this._repository);
+
+  // ignore: unused_field
+  final IAccountRepository _repository;
+
+  /// Executes the use case.
+  Stream<Money> call(String id, String currencyCode) {
+    throw UnimplementedError(
+      'GetAccountBalanceUseCase.call is not implemented',
+    );
+  }
+}

--- a/lib/domain/usecases/account/update_account_use_case.dart
+++ b/lib/domain/usecases/account/update_account_use_case.dart
@@ -1,0 +1,20 @@
+// lib/domain/usecases/account/update_account_use_case.dart
+//
+// Use case: update an existing account's mutable fields.
+
+import 'package:variance/domain/core/result.dart';
+import 'package:variance/domain/entities/account.dart';
+import 'package:variance/domain/repositories/i_account_repository.dart';
+
+/// Updates mutable fields of an existing account.
+class UpdateAccountUseCase {
+  const UpdateAccountUseCase(this._repository);
+
+  // ignore: unused_field
+  final IAccountRepository _repository;
+
+  /// Executes the use case.
+  Future<Result<Account>> call(Account account) {
+    throw UnimplementedError('UpdateAccountUseCase.call is not implemented');
+  }
+}

--- a/lib/domain/usecases/account/watch_accounts_use_case.dart
+++ b/lib/domain/usecases/account/watch_accounts_use_case.dart
@@ -1,0 +1,19 @@
+// lib/domain/usecases/account/watch_accounts_use_case.dart
+//
+// Use case: watch the live list of accounts.
+
+import 'package:variance/domain/entities/account.dart';
+import 'package:variance/domain/repositories/i_account_repository.dart';
+
+/// Returns a reactive stream of all non-system, non-deleted accounts.
+class WatchAccountsUseCase {
+  const WatchAccountsUseCase(this._repository);
+
+  // ignore: unused_field
+  final IAccountRepository _repository;
+
+  /// Executes the use case.
+  Stream<List<Account>> call() {
+    throw UnimplementedError('WatchAccountsUseCase.call is not implemented');
+  }
+}

--- a/lib/domain/usecases/category/create_category_use_case.dart
+++ b/lib/domain/usecases/category/create_category_use_case.dart
@@ -1,0 +1,20 @@
+// lib/domain/usecases/category/create_category_use_case.dart
+//
+// Use case: create a new category.
+
+import 'package:variance/domain/core/result.dart';
+import 'package:variance/domain/entities/category.dart';
+import 'package:variance/domain/repositories/i_category_repository.dart';
+
+/// Creates a new category and persists it.
+class CreateCategoryUseCase {
+  const CreateCategoryUseCase(this._repository);
+
+  // ignore: unused_field
+  final ICategoryRepository _repository;
+
+  /// Executes the use case.
+  Future<Result<Category>> call(Category category) {
+    throw UnimplementedError('CreateCategoryUseCase.call is not implemented');
+  }
+}

--- a/lib/domain/usecases/category/delete_category_use_case.dart
+++ b/lib/domain/usecases/category/delete_category_use_case.dart
@@ -1,0 +1,32 @@
+// lib/domain/usecases/category/delete_category_use_case.dart
+//
+// Use case: soft-delete a category.
+
+import 'package:variance/domain/core/result.dart';
+import 'package:variance/domain/repositories/i_category_repository.dart';
+
+/// Input for deleting a category.
+class DeleteCategoryInput {
+  const DeleteCategoryInput({required this.id, this.replacementId});
+
+  /// UUID of the category to soft-delete.
+  final String id;
+
+  /// Optional UUID of the replacement category for existing transactions.
+  final String? replacementId;
+}
+
+/// Soft-deletes a category and optionally re-assigns linked transactions.
+///
+/// Protected categories (BAI, BAE) return a [BusinessRuleFailure].
+class DeleteCategoryUseCase {
+  const DeleteCategoryUseCase(this._repository);
+
+  // ignore: unused_field
+  final ICategoryRepository _repository;
+
+  /// Executes the use case.
+  Future<Result<void>> call(DeleteCategoryInput input) {
+    throw UnimplementedError('DeleteCategoryUseCase.call is not implemented');
+  }
+}

--- a/lib/domain/usecases/category/update_category_use_case.dart
+++ b/lib/domain/usecases/category/update_category_use_case.dart
@@ -1,0 +1,20 @@
+// lib/domain/usecases/category/update_category_use_case.dart
+//
+// Use case: update an existing category.
+
+import 'package:variance/domain/core/result.dart';
+import 'package:variance/domain/entities/category.dart';
+import 'package:variance/domain/repositories/i_category_repository.dart';
+
+/// Updates a category's mutable fields.
+class UpdateCategoryUseCase {
+  const UpdateCategoryUseCase(this._repository);
+
+  // ignore: unused_field
+  final ICategoryRepository _repository;
+
+  /// Executes the use case.
+  Future<Result<Category>> call(Category category) {
+    throw UnimplementedError('UpdateCategoryUseCase.call is not implemented');
+  }
+}

--- a/lib/domain/usecases/currency/get_exchange_rate_use_case.dart
+++ b/lib/domain/usecases/currency/get_exchange_rate_use_case.dart
@@ -1,0 +1,40 @@
+// lib/domain/usecases/currency/get_exchange_rate_use_case.dart
+//
+// Use case: retrieve an exchange rate for a currency pair.
+
+import 'package:decimal/decimal.dart';
+import 'package:variance/domain/core/result.dart';
+import 'package:variance/domain/repositories/i_exchange_rate_repository.dart';
+
+/// Input for retrieving an exchange rate.
+class GetExchangeRateInput {
+  const GetExchangeRateInput({
+    required this.from,
+    required this.to,
+    required this.date,
+  });
+
+  /// ISO 4217 source currency code.
+  final String from;
+
+  /// ISO 4217 target currency code.
+  final String to;
+
+  /// ISO 8601 date string (e.g. '2025-05-07').
+  final String date;
+}
+
+/// Retrieves the exchange rate for a given currency pair and date.
+///
+/// Cache-first: reads the local cache and falls back to indicating staleness.
+class GetExchangeRateUseCase {
+  const GetExchangeRateUseCase(this._repository);
+
+  // ignore: unused_field
+  final IExchangeRateRepository _repository;
+
+  /// Executes the use case.
+  Future<Result<Decimal>> call(GetExchangeRateInput input) {
+    throw UnimplementedError('GetExchangeRateUseCase.call is not implemented');
+  }
+}

--- a/lib/domain/usecases/currency/refresh_exchange_rates_use_case.dart
+++ b/lib/domain/usecases/currency/refresh_exchange_rates_use_case.dart
@@ -1,0 +1,23 @@
+// lib/domain/usecases/currency/refresh_exchange_rates_use_case.dart
+//
+// Use case: refresh exchange rates from the remote API.
+
+import 'package:variance/domain/core/result.dart';
+import 'package:variance/domain/repositories/i_exchange_rate_repository.dart';
+
+/// Fetches the latest exchange rates and upserts them into the local cache.
+///
+/// Called by WorkManager on a background schedule and on manual user refresh.
+class RefreshExchangeRatesUseCase {
+  const RefreshExchangeRatesUseCase(this._repository);
+
+  // ignore: unused_field
+  final IExchangeRateRepository _repository;
+
+  /// Executes the use case.
+  Future<Result<void>> call() {
+    throw UnimplementedError(
+      'RefreshExchangeRatesUseCase.call is not implemented',
+    );
+  }
+}

--- a/lib/domain/usecases/home/get_catch_up_banner_use_case.dart
+++ b/lib/domain/usecases/home/get_catch_up_banner_use_case.dart
@@ -1,0 +1,25 @@
+// lib/domain/usecases/home/get_catch_up_banner_use_case.dart
+//
+// Use case: retrieve overdue recurring templates for the catch-up banner.
+
+import 'package:variance/domain/core/result.dart';
+import 'package:variance/domain/entities/recurring_template.dart';
+import 'package:variance/domain/repositories/i_recurring_template_repository.dart';
+
+/// Returns all recurring templates with overdue (past-due) pending occurrences.
+///
+/// The count of returned templates drives the "Catch up" alert strip on the
+/// home screen.
+class GetCatchUpBannerUseCase {
+  const GetCatchUpBannerUseCase(this._repository);
+
+  // ignore: unused_field
+  final IRecurringTemplateRepository _repository;
+
+  /// Executes the use case.
+  Future<Result<List<RecurringTemplate>>> call() {
+    throw UnimplementedError(
+      'GetCatchUpBannerUseCase.call is not implemented',
+    );
+  }
+}

--- a/lib/domain/usecases/home/watch_monthly_summary_use_case.dart
+++ b/lib/domain/usecases/home/watch_monthly_summary_use_case.dart
@@ -1,0 +1,39 @@
+// lib/domain/usecases/home/watch_monthly_summary_use_case.dart
+//
+// Use case: watch the monthly income/expense/net summary for the home screen.
+
+import 'package:variance/domain/entities/money.dart';
+
+/// Monthly summary aggregates for the home screen.
+class MonthlySummary {
+  const MonthlySummary({
+    required this.income,
+    required this.expenses,
+    required this.net,
+  });
+
+  /// Total income for the month (per currency).
+  final List<Money> income;
+
+  /// Total expenses for the month (per currency).
+  final List<Money> expenses;
+
+  /// Net balance (income − expenses) per currency.
+  final List<Money> net;
+}
+
+/// Watches the aggregated monthly income, expense, and net values.
+///
+/// No direct repository dependency — aggregates from accounts + transactions.
+class WatchMonthlySummaryUseCase {
+  const WatchMonthlySummaryUseCase();
+
+  /// Executes the use case.
+  ///
+  /// [year] and [month] use calendar values.
+  Stream<MonthlySummary> call(int year, int month) {
+    throw UnimplementedError(
+      'WatchMonthlySummaryUseCase.call is not implemented',
+    );
+  }
+}

--- a/lib/domain/usecases/home/watch_net_worth_use_case.dart
+++ b/lib/domain/usecases/home/watch_net_worth_use_case.dart
@@ -1,0 +1,16 @@
+// lib/domain/usecases/home/watch_net_worth_use_case.dart
+//
+// Use case: watch the total net worth converted to the home currency.
+
+import 'package:variance/domain/entities/money.dart';
+
+/// Watches the total net worth across all include_in_net_worth accounts,
+/// converted to the home currency at the latest exchange rates.
+class WatchNetWorthUseCase {
+  const WatchNetWorthUseCase();
+
+  /// Executes the use case.
+  Stream<Money> call() {
+    throw UnimplementedError('WatchNetWorthUseCase.call is not implemented');
+  }
+}

--- a/lib/domain/usecases/installment/close_installment_plan_use_case.dart
+++ b/lib/domain/usecases/installment/close_installment_plan_use_case.dart
@@ -1,0 +1,23 @@
+// lib/domain/usecases/installment/close_installment_plan_use_case.dart
+//
+// Use case: close an installment plan early.
+
+import 'package:variance/domain/core/result.dart';
+import 'package:variance/domain/repositories/i_installment_plan_repository.dart';
+
+/// Closes the installment plan identified by [id] early.
+///
+/// Cancels all pending installment occurrences and archives the template.
+class CloseInstallmentPlanUseCase {
+  const CloseInstallmentPlanUseCase(this._repository);
+
+  // ignore: unused_field
+  final IInstallmentPlanRepository _repository;
+
+  /// Executes the use case.
+  Future<Result<void>> call(String id) {
+    throw UnimplementedError(
+      'CloseInstallmentPlanUseCase.call is not implemented',
+    );
+  }
+}

--- a/lib/domain/usecases/installment/create_installment_plan_use_case.dart
+++ b/lib/domain/usecases/installment/create_installment_plan_use_case.dart
@@ -1,0 +1,38 @@
+// lib/domain/usecases/installment/create_installment_plan_use_case.dart
+//
+// Use case: create a new installment plan.
+
+import 'package:variance/domain/core/result.dart';
+import 'package:variance/domain/entities/installment_plan.dart';
+import 'package:variance/domain/entities/recurring_template.dart';
+import 'package:variance/domain/repositories/i_installment_plan_repository.dart';
+
+/// Input pairing the installment template with its plan metadata.
+class CreateInstallmentPlanInput {
+  const CreateInstallmentPlanInput({
+    required this.template,
+    required this.plan,
+  });
+
+  /// The recurring template (isInstallment = true).
+  final RecurringTemplate template;
+
+  /// The plan metadata.
+  final InstallmentPlan plan;
+}
+
+/// Creates a new installment plan together with its template and eagerly
+/// materializes all installment occurrences.
+class CreateInstallmentPlanUseCase {
+  const CreateInstallmentPlanUseCase(this._repository);
+
+  // ignore: unused_field
+  final IInstallmentPlanRepository _repository;
+
+  /// Executes the use case.
+  Future<Result<InstallmentPlan>> call(CreateInstallmentPlanInput input) {
+    throw UnimplementedError(
+      'CreateInstallmentPlanUseCase.call is not implemented',
+    );
+  }
+}

--- a/lib/domain/usecases/recurring/create_recurring_template_use_case.dart
+++ b/lib/domain/usecases/recurring/create_recurring_template_use_case.dart
@@ -1,0 +1,22 @@
+// lib/domain/usecases/recurring/create_recurring_template_use_case.dart
+//
+// Use case: create a new recurring template.
+
+import 'package:variance/domain/core/result.dart';
+import 'package:variance/domain/entities/recurring_template.dart';
+import 'package:variance/domain/repositories/i_recurring_template_repository.dart';
+
+/// Creates a new recurring template and materializes its initial occurrences.
+class CreateRecurringTemplateUseCase {
+  const CreateRecurringTemplateUseCase(this._repository);
+
+  // ignore: unused_field
+  final IRecurringTemplateRepository _repository;
+
+  /// Executes the use case.
+  Future<Result<RecurringTemplate>> call(RecurringTemplate template) {
+    throw UnimplementedError(
+      'CreateRecurringTemplateUseCase.call is not implemented',
+    );
+  }
+}

--- a/lib/domain/usecases/recurring/post_due_occurrences_use_case.dart
+++ b/lib/domain/usecases/recurring/post_due_occurrences_use_case.dart
@@ -1,0 +1,36 @@
+// lib/domain/usecases/recurring/post_due_occurrences_use_case.dart
+//
+// Use case: post all due recurring occurrences on app launch.
+
+import 'package:variance/domain/core/result.dart';
+import 'package:variance/domain/repositories/i_recurring_template_repository.dart';
+import 'package:variance/domain/repositories/i_scheduled_occurrence_repository.dart';
+import 'package:variance/domain/repositories/i_transaction_repository.dart';
+
+/// Posts all auto_post occurrences whose scheduled_date ≤ now.
+///
+/// Returns the count of occurrences that were successfully posted.
+/// Called on every app launch (AppInitializer) and by the background worker.
+class PostDueOccurrencesUseCase {
+  const PostDueOccurrencesUseCase(
+    this._templateRepository,
+    this._occurrenceRepository,
+    this._transactionRepository,
+  );
+
+  // ignore: unused_field
+  final IRecurringTemplateRepository _templateRepository;
+  // ignore: unused_field
+  final IScheduledOccurrenceRepository _occurrenceRepository;
+  // ignore: unused_field
+  final ITransactionRepository _transactionRepository;
+
+  /// Executes the use case.
+  ///
+  /// Returns [Ok(n)] where n is the number of occurrences posted.
+  Future<Result<int>> call() {
+    throw UnimplementedError(
+      'PostDueOccurrencesUseCase.call is not implemented',
+    );
+  }
+}

--- a/lib/domain/usecases/recurring/skip_occurrence_use_case.dart
+++ b/lib/domain/usecases/recurring/skip_occurrence_use_case.dart
@@ -1,0 +1,19 @@
+// lib/domain/usecases/recurring/skip_occurrence_use_case.dart
+//
+// Use case: manually skip a pending scheduled occurrence.
+
+import 'package:variance/domain/core/result.dart';
+import 'package:variance/domain/repositories/i_scheduled_occurrence_repository.dart';
+
+/// Marks the scheduled occurrence with [id] as skipped.
+class SkipOccurrenceUseCase {
+  const SkipOccurrenceUseCase(this._repository);
+
+  // ignore: unused_field
+  final IScheduledOccurrenceRepository _repository;
+
+  /// Executes the use case.
+  Future<Result<void>> call(String id) {
+    throw UnimplementedError('SkipOccurrenceUseCase.call is not implemented');
+  }
+}

--- a/lib/domain/usecases/recurring/update_recurring_template_use_case.dart
+++ b/lib/domain/usecases/recurring/update_recurring_template_use_case.dart
@@ -1,0 +1,25 @@
+// lib/domain/usecases/recurring/update_recurring_template_use_case.dart
+//
+// Use case: update editable fields of a recurring template.
+
+import 'package:variance/domain/core/result.dart';
+import 'package:variance/domain/entities/recurring_template.dart';
+import 'package:variance/domain/repositories/i_recurring_template_repository.dart';
+
+/// Updates mutable fields of an existing recurring template.
+///
+/// Immutable fields (transaction type, recurrence spec, start/end date) are
+/// ignored by the repository implementation.
+class UpdateRecurringTemplateUseCase {
+  const UpdateRecurringTemplateUseCase(this._repository);
+
+  // ignore: unused_field
+  final IRecurringTemplateRepository _repository;
+
+  /// Executes the use case.
+  Future<Result<RecurringTemplate>> call(RecurringTemplate template) {
+    throw UnimplementedError(
+      'UpdateRecurringTemplateUseCase.call is not implemented',
+    );
+  }
+}

--- a/lib/domain/usecases/settings/update_app_settings_use_case.dart
+++ b/lib/domain/usecases/settings/update_app_settings_use_case.dart
@@ -1,0 +1,21 @@
+// lib/domain/usecases/settings/update_app_settings_use_case.dart
+//
+// Use case: update one or more app settings.
+
+import 'package:variance/domain/core/result.dart';
+import 'package:variance/domain/repositories/i_app_settings_repository.dart';
+
+/// Applies a partial update to the app settings.
+class UpdateAppSettingsUseCase {
+  const UpdateAppSettingsUseCase(this._repository);
+
+  // ignore: unused_field
+  final IAppSettingsRepository _repository;
+
+  /// Executes the use case.
+  Future<Result<void>> call(AppSettingsPatch patch) {
+    throw UnimplementedError(
+      'UpdateAppSettingsUseCase.call is not implemented',
+    );
+  }
+}

--- a/lib/domain/usecases/transaction/check_duplicate_use_case.dart
+++ b/lib/domain/usecases/transaction/check_duplicate_use_case.dart
@@ -1,0 +1,19 @@
+// lib/domain/usecases/transaction/check_duplicate_use_case.dart
+//
+// Use case: check whether a draft transaction is a likely duplicate.
+
+import 'package:variance/domain/core/result.dart';
+import 'package:variance/domain/entities/transaction.dart';
+
+/// Checks whether [draft] is a likely duplicate of a recently posted
+/// transaction (same amount, account, type within a short time window).
+class CheckDuplicateUseCase {
+  const CheckDuplicateUseCase();
+
+  /// Executes the duplicate check.
+  ///
+  /// Returns [Ok(true)] if a probable duplicate exists.
+  Future<Result<bool>> call(Transaction draft) {
+    throw UnimplementedError('CheckDuplicateUseCase.call is not implemented');
+  }
+}

--- a/lib/domain/usecases/transaction/check_overdraft_use_case.dart
+++ b/lib/domain/usecases/transaction/check_overdraft_use_case.dart
@@ -1,0 +1,19 @@
+// lib/domain/usecases/transaction/check_overdraft_use_case.dart
+//
+// Use case: check whether a draft transaction would cause an overdraft.
+
+import 'package:variance/domain/core/result.dart';
+import 'package:variance/domain/entities/transaction.dart';
+
+/// Checks whether posting [draft] would cause the source account balance to
+/// go negative (future business rule — v1 may return false by default).
+class CheckOverdraftUseCase {
+  const CheckOverdraftUseCase();
+
+  /// Executes the overdraft check.
+  ///
+  /// Returns [Ok(true)] if posting [draft] would result in a negative balance.
+  Future<Result<bool>> call(Transaction draft) {
+    throw UnimplementedError('CheckOverdraftUseCase.call is not implemented');
+  }
+}

--- a/lib/domain/usecases/transaction/create_transaction_use_case.dart
+++ b/lib/domain/usecases/transaction/create_transaction_use_case.dart
@@ -1,0 +1,28 @@
+// lib/domain/usecases/transaction/create_transaction_use_case.dart
+//
+// Use case: create a new transaction and post it to the ledger.
+
+import 'package:variance/domain/core/result.dart';
+import 'package:variance/domain/entities/transaction.dart';
+import 'package:variance/domain/repositories/i_transaction_repository.dart';
+
+/// Creates a new transaction from a validated [Transaction] draft.
+///
+/// Calls [ITransactionRepository.create]; delegates ledger-entry generation
+/// to the LedgerEngine inside the repository implementation.
+class CreateTransactionUseCase {
+  const CreateTransactionUseCase(this._repository);
+
+  // ignore: unused_field
+  final ITransactionRepository _repository;
+
+  /// Executes the use case.
+  ///
+  /// [draft] must be a fully validated transaction in status = pending.
+  /// Returns the persisted [Transaction] on success.
+  Future<Result<Transaction>> call(Transaction draft) {
+    throw UnimplementedError(
+      'CreateTransactionUseCase.call is not implemented',
+    );
+  }
+}

--- a/lib/domain/usecases/transaction/edit_transaction_use_case.dart
+++ b/lib/domain/usecases/transaction/edit_transaction_use_case.dart
@@ -1,0 +1,26 @@
+// lib/domain/usecases/transaction/edit_transaction_use_case.dart
+//
+// Use case: edit an existing posted transaction.
+//
+// Routes to correctFinancial (reversal + correction pair) if any financial
+// field changed, or to updateNonFinancial for title/description/date/payee.
+
+import 'package:variance/domain/core/result.dart';
+import 'package:variance/domain/entities/transaction.dart';
+import 'package:variance/domain/repositories/i_transaction_repository.dart';
+
+/// Edits an existing transaction identified by [id] using [updated].
+class EditTransactionUseCase {
+  const EditTransactionUseCase(this._repository);
+
+  // ignore: unused_field
+  final ITransactionRepository _repository;
+
+  /// Executes the use case.
+  ///
+  /// Determines whether the edit requires a correction chain or an in-place
+  /// update by comparing [updated] to the existing record.
+  Future<Result<Transaction>> call(String id, Transaction updated) {
+    throw UnimplementedError('EditTransactionUseCase.call is not implemented');
+  }
+}

--- a/lib/domain/usecases/transaction/search_transactions_use_case.dart
+++ b/lib/domain/usecases/transaction/search_transactions_use_case.dart
@@ -1,0 +1,33 @@
+// lib/domain/usecases/transaction/search_transactions_use_case.dart
+//
+// Use case: full-text search across transactions.
+
+import 'package:variance/domain/core/result.dart';
+import 'package:variance/domain/entities/transaction.dart';
+import 'package:variance/domain/repositories/i_transaction_repository.dart';
+
+/// Full-text search input parameters.
+class SearchTransactionsInput {
+  const SearchTransactionsInput({
+    required this.query,
+    this.filters,
+  });
+
+  final String query;
+  final TransactionFilters? filters;
+}
+
+/// Searches transactions using FTS5 and optional filters.
+class SearchTransactionsUseCase {
+  const SearchTransactionsUseCase(this._repository);
+
+  // ignore: unused_field
+  final ITransactionRepository _repository;
+
+  /// Executes the full-text search.
+  Future<Result<List<Transaction>>> call(SearchTransactionsInput input) {
+    throw UnimplementedError(
+      'SearchTransactionsUseCase.call is not implemented',
+    );
+  }
+}

--- a/lib/domain/usecases/transaction/void_transaction_use_case.dart
+++ b/lib/domain/usecases/transaction/void_transaction_use_case.dart
@@ -1,0 +1,21 @@
+// lib/domain/usecases/transaction/void_transaction_use_case.dart
+//
+// Use case: void a single transaction.
+
+import 'package:variance/domain/core/result.dart';
+import 'package:variance/domain/repositories/i_transaction_repository.dart';
+
+/// Voids the transaction identified by [id].
+///
+/// A voided transaction no longer participates in balance calculations.
+class VoidTransactionUseCase {
+  const VoidTransactionUseCase(this._repository);
+
+  // ignore: unused_field
+  final ITransactionRepository _repository;
+
+  /// Executes the use case.
+  Future<Result<void>> call(String id) {
+    throw UnimplementedError('VoidTransactionUseCase.call is not implemented');
+  }
+}

--- a/lib/domain/usecases/transaction/watch_monthly_transactions_use_case.dart
+++ b/lib/domain/usecases/transaction/watch_monthly_transactions_use_case.dart
@@ -1,0 +1,30 @@
+// lib/domain/usecases/transaction/watch_monthly_transactions_use_case.dart
+//
+// Use case: watch the transaction list for a given calendar month.
+
+import 'package:variance/domain/entities/transaction.dart';
+import 'package:variance/domain/repositories/i_transaction_repository.dart';
+
+/// Watches all display-eligible transactions for the given [year] and [month].
+///
+/// Returns a Stream; errors surface via the stream's error channel.
+class WatchMonthlyTransactionsUseCase {
+  const WatchMonthlyTransactionsUseCase(this._repository);
+
+  // ignore: unused_field
+  final ITransactionRepository _repository;
+
+  /// Executes the use case.
+  ///
+  /// [year] — four-digit calendar year.
+  /// [month] — 1-based month (1 = January, 12 = December).
+  Stream<List<Transaction>> call(
+    int year,
+    int month, {
+    TransactionFilters? filters,
+  }) {
+    throw UnimplementedError(
+      'WatchMonthlyTransactionsUseCase.call is not implemented',
+    );
+  }
+}

--- a/test/unit/domain/core/result_test.dart
+++ b/test/unit/domain/core/result_test.dart
@@ -1,0 +1,124 @@
+// test/unit/domain/core/result_test.dart
+//
+// Tests for Result<T>, Ok<T>, and Err<T> sealed types.
+//
+// Test cases:
+//   1. Ok carries the correct value
+//   2. Ok is a Result<T>
+//   3. Err carries the correct Failure
+//   4. Err is a Result<T>
+//   5. Switch exhaustiveness: Ok branch executes on Ok
+//   6. Switch exhaustiveness: Err branch executes on Err
+//   7. Ok<void> is constructible with null
+//   8. Nested Result is supported (Result<Result<int>>)
+//   9. DatabaseFailure carries message
+//  10. ValidationFailure carries message
+//  11. NetworkFailure carries message
+//  12. NotFoundFailure carries message
+//  13. BusinessRuleFailure carries message
+//  14. All Failure subtypes are Failure instances
+//  15. Different Failure subtypes are not equal by type
+
+import 'package:flutter_test/flutter_test.dart';
+import 'package:variance/domain/core/failure.dart';
+import 'package:variance/domain/core/result.dart';
+
+void main() {
+  group('Ok', () {
+    test('1. carries the correct value', () {
+      const result = Ok(42);
+      expect(result.value, equals(42));
+    });
+
+    test('2. is a Result<int>', () {
+      const result = Ok(1);
+      expect(result, isA<Result<int>>());
+    });
+
+    test('7. Ok<void> is constructible with null value', () {
+      const result = Ok<void>(null);
+      expect(result, isA<Ok<void>>());
+    });
+
+    test('8. nested Result is supported', () {
+      const inner = Ok(10);
+      const outer = Ok<Result<int>>(inner);
+      expect(outer.value, isA<Ok<int>>());
+    });
+  });
+
+  group('Err', () {
+    test('3. carries the correct Failure', () {
+      const failure = DatabaseFailure('db error');
+      const result = Err<int>(failure);
+      expect(result.failure, equals(failure));
+    });
+
+    test('4. is a Result<int>', () {
+      const result = Err<int>(DatabaseFailure('msg'));
+      expect(result, isA<Result<int>>());
+    });
+  });
+
+  group('Switch exhaustiveness', () {
+    test('5. Ok branch executes on Ok', () {
+      final Result<int> result = Ok(7);
+      final output = switch (result) {
+        Ok(:final value) => 'ok:$value',
+        Err(:final failure) => 'err:${failure.message}',
+      };
+      expect(output, equals('ok:7'));
+    });
+
+    test('6. Err branch executes on Err', () {
+      final Result<int> result = Err(const ValidationFailure('bad input'));
+      final output = switch (result) {
+        Ok(:final value) => 'ok:$value',
+        Err(:final failure) => 'err:${failure.message}',
+      };
+      expect(output, equals('err:bad input'));
+    });
+  });
+
+  group('Failure hierarchy', () {
+    test('9. DatabaseFailure carries message', () {
+      const f = DatabaseFailure('sqlite error');
+      expect(f.message, equals('sqlite error'));
+    });
+
+    test('10. ValidationFailure carries message', () {
+      const f = ValidationFailure('amount must be positive');
+      expect(f.message, equals('amount must be positive'));
+    });
+
+    test('11. NetworkFailure carries message', () {
+      const f = NetworkFailure('timeout');
+      expect(f.message, equals('timeout'));
+    });
+
+    test('12. NotFoundFailure carries message', () {
+      const f = NotFoundFailure('account not found');
+      expect(f.message, equals('account not found'));
+    });
+
+    test('13. BusinessRuleFailure carries message', () {
+      const f = BusinessRuleFailure('debit != credit');
+      expect(f.message, equals('debit != credit'));
+    });
+
+    test('14. all Failure subtypes are Failure instances', () {
+      expect(const DatabaseFailure(''), isA<Failure>());
+      expect(const ValidationFailure(''), isA<Failure>());
+      expect(const NetworkFailure(''), isA<Failure>());
+      expect(const NotFoundFailure(''), isA<Failure>());
+      expect(const BusinessRuleFailure(''), isA<Failure>());
+    });
+
+    test('15. distinct Failure subtypes are not the same type', () {
+      const Failure a = DatabaseFailure('x');
+      const Failure b = ValidationFailure('x');
+      expect(a, isNot(isA<ValidationFailure>()));
+      expect(b, isNot(isA<DatabaseFailure>()));
+    });
+  });
+}

--- a/test/unit/domain/entities/entities_test.dart
+++ b/test/unit/domain/entities/entities_test.dart
@@ -1,0 +1,295 @@
+// test/unit/domain/entities/entities_test.dart
+//
+// Smoke tests for all 16 Freezed domain entities.
+// Verifies: constructability, copyWith, equality, default values.
+//
+// Test cases:
+//   1. Account: constructs with required fields; default isDeleted = false
+//   2. Account: copyWith produces a new immutable instance
+//   3. Account: structural equality (two same-field instances are equal)
+//   4. Transaction: constructs; default purpose = user
+//   5. Transaction: status field round-trips via copyWith
+//   6. Entry: constructs; mutually exclusive account/category fields nullable
+//   7. Category: constructs; default isProtected = false
+//   8. Tag: constructs minimal fields
+//   9. Payee: constructs; default isDeleted = false
+//  10. Currency: constructs; default minorUnits = 2
+//  11. ExchangeRate: constructs all required fields
+//  12. Budget: constructs; default rollover = false
+//  13. BudgetPeriod: constructs; default carriedOverMinor = 0
+//  14. RecurringTemplate: constructs; default status = active
+//  15. ScheduledOccurrence: constructs; default status = pending
+//  16. InstallmentPlan: constructs all required fields
+//  17. InstallmentOccurrence: constructs; default status = pending
+//  18. AppSettings: constructs with all defaults; homeCurrency = INR
+//  19. Draft: constructs with required fields
+//  20. Money: constructs; used in equality check
+
+import 'package:flutter_test/flutter_test.dart';
+import 'package:variance/domain/entities/account.dart';
+import 'package:variance/domain/entities/app_settings.dart';
+import 'package:variance/domain/entities/budget.dart';
+import 'package:variance/domain/entities/budget_period.dart';
+import 'package:variance/domain/entities/category.dart';
+import 'package:variance/domain/entities/currency.dart';
+import 'package:variance/domain/entities/draft.dart';
+import 'package:variance/domain/entities/entry.dart';
+import 'package:variance/domain/entities/exchange_rate.dart';
+import 'package:variance/domain/entities/installment_occurrence.dart';
+import 'package:variance/domain/entities/installment_plan.dart';
+import 'package:variance/domain/entities/money.dart';
+import 'package:variance/domain/entities/payee.dart';
+import 'package:variance/domain/entities/recurring_template.dart';
+import 'package:variance/domain/entities/scheduled_occurrence.dart';
+import 'package:variance/domain/entities/tag.dart';
+import 'package:variance/domain/entities/transaction.dart';
+
+void main() {
+  const now = 1715000000; // fixed epoch for tests
+
+  group('Account', () {
+    const account = Account(
+      id: 'a1',
+      name: 'Savings',
+      accountCategory: AccountCategory.bankAccount,
+      currencyCode: 'INR',
+      createdAt: now,
+      updatedAt: now,
+    );
+
+    test('1. constructs with required fields; default isDeleted = false', () {
+      expect(account.id, equals('a1'));
+      expect(account.isDeleted, isFalse);
+      expect(account.initialBalanceMinor, equals(0));
+    });
+
+    test('2. copyWith produces a new immutable instance', () {
+      final updated = account.copyWith(name: 'Checking');
+      expect(updated.name, equals('Checking'));
+      expect(account.name, equals('Savings')); // original unchanged
+    });
+
+    test('3. structural equality holds', () {
+      const same = Account(
+        id: 'a1',
+        name: 'Savings',
+        accountCategory: AccountCategory.bankAccount,
+        currencyCode: 'INR',
+        createdAt: now,
+        updatedAt: now,
+      );
+      expect(account, equals(same));
+    });
+  });
+
+  group('Transaction', () {
+    const tx = Transaction(
+      id: 't1',
+      type: TransactionType.expense,
+      status: TransactionStatus.pending,
+      dateTime: now,
+      amountMinor: 5000,
+      currencyCode: 'INR',
+      createdAt: now,
+      updatedAt: now,
+    );
+
+    test('4. constructs; default purpose = user', () {
+      expect(tx.purpose, equals(TransactionPurpose.user));
+    });
+
+    test('5. status field round-trips via copyWith', () {
+      final posted = tx.copyWith(status: TransactionStatus.posted);
+      expect(posted.status, equals(TransactionStatus.posted));
+      expect(tx.status, equals(TransactionStatus.pending));
+    });
+  });
+
+  group('Entry', () {
+    test('6. constructs; account/category fields are nullable', () {
+      const entry = Entry(
+        id: 'e1',
+        transactionId: 't1',
+        accountId: 'a1',
+        side: EntrySide.debit,
+        amountMinor: 5000,
+        currencyCode: 'INR',
+        createdAt: now,
+      );
+      expect(entry.categoryId, isNull);
+    });
+  });
+
+  group('Category', () {
+    test('7. constructs; default isProtected = false', () {
+      const cat = Category(
+        id: 'c1',
+        treeType: CategoryTreeType.expense,
+        name: 'Food',
+        iconRef: 'restaurant',
+        createdAt: now,
+        updatedAt: now,
+      );
+      expect(cat.isProtected, isFalse);
+      expect(cat.parentId, isNull);
+    });
+  });
+
+  group('Tag', () {
+    test('8. constructs minimal fields', () {
+      const tag = Tag(id: 'tg1', name: 'groceries', createdAt: now);
+      expect(tag.name, equals('groceries'));
+    });
+  });
+
+  group('Payee', () {
+    test('9. constructs; default isDeleted = false', () {
+      const payee = Payee(
+        id: 'p1',
+        name: 'Amazon',
+        createdAt: now,
+        updatedAt: now,
+      );
+      expect(payee.isDeleted, isFalse);
+    });
+  });
+
+  group('Currency', () {
+    test('10. constructs; default minorUnits = 2', () {
+      const currency = Currency(code: 'USD', name: 'US Dollar', symbol: '\$');
+      expect(currency.minorUnits, equals(2));
+      expect(currency.isActive, isTrue);
+    });
+  });
+
+  group('ExchangeRate', () {
+    test('11. constructs all required fields', () {
+      const rate = ExchangeRate(
+        id: 1,
+        fromCurrency: 'USD',
+        toCurrency: 'INR',
+        rateMicro: 83000000,
+        fetchedAt: now,
+        rateDate: '2025-05-07',
+      );
+      expect(rate.rateMicro, equals(83000000));
+    });
+  });
+
+  group('Budget', () {
+    test('12. constructs; default rollover = false', () {
+      const budget = Budget(
+        id: 'b1',
+        name: 'Monthly groceries',
+        amountMinor: 1000000,
+        currencyCode: 'INR',
+        periodType: BudgetPeriodType.monthly,
+        createdAt: now,
+        updatedAt: now,
+      );
+      expect(budget.rollover, isFalse);
+      expect(budget.isActive, isTrue);
+    });
+  });
+
+  group('BudgetPeriod', () {
+    test('13. constructs; default carriedOverMinor = 0', () {
+      const period = BudgetPeriod(
+        id: 'bp1',
+        budgetId: 'b1',
+        periodStart: now,
+        periodEnd: now + 2592000,
+        budgetedMinor: 1000000,
+        createdAt: now,
+      );
+      expect(period.carriedOverMinor, equals(0));
+    });
+  });
+
+  group('RecurringTemplate', () {
+    test('14. constructs; default status = active', () {
+      const template = RecurringTemplate(
+        id: 'rt1',
+        transactionType: 'expense',
+        amountMinor: 50000,
+        currencyCode: 'INR',
+        recurrenceN: 1,
+        recurrenceUnit: RecurrenceUnit.month,
+        startDate: now,
+        createdAt: now,
+        updatedAt: now,
+      );
+      expect(template.status, equals(RecurringTemplateStatus.active));
+      expect(template.isInstallment, isFalse);
+    });
+  });
+
+  group('ScheduledOccurrence', () {
+    test('15. constructs; default status = pending', () {
+      const occ = ScheduledOccurrence(
+        id: 'so1',
+        templateId: 'rt1',
+        scheduledDate: now,
+        createdAt: now,
+        updatedAt: now,
+      );
+      expect(occ.status, equals(ScheduledOccurrenceStatus.pending));
+    });
+  });
+
+  group('InstallmentPlan', () {
+    test('16. constructs all required fields', () {
+      const plan = InstallmentPlan(
+        templateId: 'rt2',
+        totalConfiguredMinor: 600000,
+        numberOfInstallments: 6,
+        createdAt: now,
+      );
+      expect(plan.numberOfInstallments, equals(6));
+    });
+  });
+
+  group('InstallmentOccurrence', () {
+    test('17. constructs; default status = pending', () {
+      const occ = InstallmentOccurrence(
+        id: 'io1',
+        templateId: 'rt2',
+        sequenceNumber: 1,
+        scheduledDate: now,
+        amountMinor: 100000,
+        createdAt: now,
+        updatedAt: now,
+      );
+      expect(occ.status, equals(InstallmentOccurrenceStatus.pending));
+    });
+  });
+
+  group('AppSettings', () {
+    test('18. constructs with defaults; homeCurrency = INR', () {
+      const settings = AppSettings();
+      expect(settings.homeCurrency, equals('INR'));
+      expect(settings.animationsEnabled, isTrue);
+      expect(settings.onboardingComplete, isFalse);
+    });
+  });
+
+  group('Draft', () {
+    test('19. constructs with required fields', () {
+      const draft = Draft(
+        id: 'd1',
+        payloadJson: '{"type":"expense"}',
+        createdAt: now,
+        updatedAt: now,
+      );
+      expect(draft.payloadJson, contains('expense'));
+    });
+  });
+
+  group('Money', () {
+    test('20. structural equality holds across two instances', () {
+      const a = Money(amountMinor: 50000, currencyCode: 'USD');
+      const b = Money(amountMinor: 50000, currencyCode: 'USD');
+      expect(a, equals(b));
+    });
+  });
+}


### PR DESCRIPTION
## Summary

- **T-9**: `Result<T>` sealed type (`Ok<T>` / `Err<T>`) and `Failure` sealed hierarchy (`DatabaseFailure`, `ValidationFailure`, `NetworkFailure`, `NotFoundFailure`, `BusinessRuleFailure`) at `lib/domain/core/`
- **T-7**: All 16 `@freezed` domain entities in `lib/domain/entities/` — `Transaction`, `Entry`, `Account`, `Category`, `RecurringTemplate`, `ScheduledOccurrence`, `InstallmentPlan`, `InstallmentOccurrence`, `Budget`, `BudgetPeriod`, `Payee`, `Tag`, `Currency`, `ExchangeRate`, `AppSettings`, `Draft` — plus `Money` value object; zero Flutter dependencies, no `json_serializable` annotations
- **T-8**: 15 abstract repository interfaces in `lib/domain/repositories/` — one per aggregate, method signatures matching the API contracts doc; no concrete implementations
- **T-10**: 27 use case shells in `lib/domain/usecases/` — correct input/output types, all `call()` bodies throw `UnimplementedError`
- **T-11**: Domain purity verified — zero Flutter imports; `make domain-check` target added to `Makefile` for CI enforcement

## Test plan

- [ ] `flutter test test/unit/domain/` — 35 tests (15 for Result/Failure, 20 entity smoke tests)
- [ ] `make domain-check` — grep for Flutter imports + `flutter analyze lib/domain/`
- [ ] `flutter analyze lib/domain/` — zero issues

🤖 Generated with [Claude Code](https://claude.com/claude-code)