### PR TITLE
feat(backup): secure storage exclusion, backup screen, ZIP engine, installment close tests [T-186, T-187, T-188, T-144]

### DIFF
--- a/android/app/src/main/AndroidManifest.xml
+++ b/android/app/src/main/AndroidManifest.xml
@@ -10,10 +10,25 @@
     <!-- POST_NOTIFICATIONS: required to display local notifications on
          Android 13+ (API 33+) for remind_and_confirm occurrences (T-118). -->
     <uses-permission android:name="android.permission.POST_NOTIFICATIONS" />
+    <!--
+      android:allowBackup="true" with dataExtractionRules / fullBackupContent
+      allows selective Auto-Backup while excluding flutter_secure_storage.
+      Setting allowBackup="false" would suppress ALL backup which prevents
+      restoring non-sensitive user data; we use granular exclusion rules instead.
+
+      dataExtractionRules: API 31+ exclusion rules (cloud-backup + device-transfer).
+      fullBackupContent:   API 23–30 exclusion rules.
+
+      Both xml files exclude FlutterSecureStorage.xml to prevent PIN material
+      from appearing in device backups (OQ-SDS-SC-001, T-186).
+    -->
     <application
         android:label="app"
         android:name="${applicationName}"
-        android:icon="@mipmap/ic_launcher">
+        android:icon="@mipmap/ic_launcher"
+        android:allowBackup="true"
+        android:dataExtractionRules="@xml/data_extraction_rules"
+        android:fullBackupContent="@xml/backup_rules">
         <activity
             android:name=".MainActivity"
             android:exported="true"

--- a/android/app/src/main/res/xml/backup_rules.xml
+++ b/android/app/src/main/res/xml/backup_rules.xml
@@ -1,0 +1,37 @@
+<?xml version="1.0" encoding="utf-8"?>
+<!--
+  backup_rules.xml
+  ================
+  Android Auto-Backup exclusion rules for API 23–30 (fullBackupContent).
+
+  Purpose: exclude flutter_secure_storage data from Android device backups.
+  flutter_secure_storage uses Android EncryptedSharedPreferences backed by
+  the Android Keystore; the encrypted blobs are tied to a device-specific
+  hardware key and are therefore non-portable and useless after restore on
+  another device (or after a factory-reset).
+
+  Including these blobs in a backup exposes the encrypted PIN material to
+  backup storage (Google Drive, ADB backup) even though it cannot be decoded
+  without the original device's hardware key. The exclusion ensures that:
+    1. PIN state is always device-local (PRD §5.4.6 security requirement).
+    2. Backup-restore attacks on PIN data (OQ-SDS-SC-001) are mitigated.
+
+  Resolution: OQ-SDS-SC-001 → RESOLVED (T-186).
+
+  flutter_secure_storage default SharedPreferences file:
+    FlutterSecureStorage.defaultAccountName = "FlutterSecureStorage"
+    Stored under: shared_prefs/FlutterSecureStorage.xml
+
+  See also: data_extraction_rules.xml (API 31+ equivalent).
+-->
+<full-backup-content>
+    <!-- Exclude flutter_secure_storage shared preferences file. -->
+    <exclude
+        domain="sharedpref"
+        path="FlutterSecureStorage.xml" />
+    <!-- Exclude entire keystore-backed preference directory as a belt-and-suspenders
+         measure against future flutter_secure_storage storage location changes. -->
+    <exclude
+        domain="sharedpref"
+        path="FlutterSecureStorageAccountName.xml" />
+</full-backup-content>

--- a/android/app/src/main/res/xml/data_extraction_rules.xml
+++ b/android/app/src/main/res/xml/data_extraction_rules.xml
@@ -1,0 +1,37 @@
+<?xml version="1.0" encoding="utf-8"?>
+<!--
+  data_extraction_rules.xml
+  ==========================
+  Android Auto-Backup exclusion rules for API 31+ (dataExtractionRules).
+  Replaces fullBackupContent for Android 12 and above.
+
+  Mirrors the exclusions in backup_rules.xml (API 23–30) for the newer rule
+  format that separates cloud-backup and device-transfer policies.
+
+  Both <cloud-backup> and <device-transfer> sections exclude the same paths
+  to ensure secure-storage blobs are never transported off-device regardless
+  of backup destination.
+
+  Resolution: OQ-SDS-SC-001 → RESOLVED (T-186).
+-->
+<data-extraction-rules>
+    <cloud-backup>
+        <!-- Exclude flutter_secure_storage shared preferences files. -->
+        <exclude
+            domain="sharedpref"
+            path="FlutterSecureStorage.xml" />
+        <exclude
+            domain="sharedpref"
+            path="FlutterSecureStorageAccountName.xml" />
+    </cloud-backup>
+    <device-transfer>
+        <!-- Exclude flutter_secure_storage from device-to-device transfer.
+             Keys are hardware-bound and non-portable. -->
+        <exclude
+            domain="sharedpref"
+            path="FlutterSecureStorage.xml" />
+        <exclude
+            domain="sharedpref"
+            path="FlutterSecureStorageAccountName.xml" />
+    </device-transfer>
+</data-extraction-rules>

--- a/lib/data/repositories/app_settings_repository_impl.dart
+++ b/lib/data/repositories/app_settings_repository_impl.dart
@@ -64,6 +64,9 @@ const _kDisplayName = 'display_name';
 /// app_settings key for last exchange rate fetch epoch.
 const _kLastExchangeRateFetch = 'last_exchange_rate_fetch';
 
+/// app_settings key for last local backup export epoch (T-186, SET-07).
+const _kLastBackupAt = 'last_backup_at';
+
 /// app_settings key for the decimal separator preference.
 const _kNumberDecimalSeparator = 'number_decimal_separator';
 
@@ -197,6 +200,14 @@ class AppSettingsRepositoryImpl implements IAppSettingsRepository {
         );
       }
 
+      if (patch.lastBackupAt != null) {
+        await _dao.upsert(
+          _kLastBackupAt,
+          patch.lastBackupAt!.toString(),
+          now,
+        );
+      }
+
       return const Ok(null);
     } on Exception catch (e) {
       return Err(DatabaseFailure(e.toString()));
@@ -259,6 +270,7 @@ class AppSettingsRepositoryImpl implements IAppSettingsRepository {
       displayName: kv[_kDisplayName],
       onboardingComplete: kv[_kOnboardingComplete] == '1',
       lastExchangeRateFetch: int.tryParse(kv[_kLastExchangeRateFetch] ?? ''),
+      lastBackupAt: int.tryParse(kv[_kLastBackupAt] ?? ''),
     );
   }
 

--- a/lib/domain/entities/app_settings.dart
+++ b/lib/domain/entities/app_settings.dart
@@ -134,5 +134,12 @@ abstract class AppSettings with _$AppSettings {
 
     /// Unix epoch of the last successful exchange rate fetch.
     int? lastExchangeRateFetch,
+
+    /// Unix epoch of the last successful local backup export.
+    ///
+    /// Written by [BackupService] on successful ZIP export (T-188, SET-07).
+    /// Read by HOME-05 to determine whether to show the backup reminder badge.
+    /// Null when no backup has ever been made.
+    int? lastBackupAt,
   }) = _AppSettings;
 }

--- a/lib/domain/entities/app_settings.freezed.dart
+++ b/lib/domain/entities/app_settings.freezed.dart
@@ -71,6 +71,13 @@ mixin _$AppSettings {
   /// Unix epoch of the last successful exchange rate fetch.
   int? get lastExchangeRateFetch;
 
+  /// Unix epoch of the last successful local backup export.
+  ///
+  /// Written by [BackupService] on successful ZIP export (T-188, SET-07).
+  /// Read by HOME-05 to determine whether to show the backup reminder badge.
+  /// Null when no backup has ever been made.
+  int? get lastBackupAt;
+
   /// Create a copy of AppSettings
   /// with the given fields replaced by the non-null parameter values.
   @JsonKey(includeFromJson: false, includeToJson: false)
@@ -121,7 +128,9 @@ mixin _$AppSettings {
             (identical(other.schemaBackupVersion, schemaBackupVersion) ||
                 other.schemaBackupVersion == schemaBackupVersion) &&
             (identical(other.lastExchangeRateFetch, lastExchangeRateFetch) ||
-                other.lastExchangeRateFetch == lastExchangeRateFetch));
+                other.lastExchangeRateFetch == lastExchangeRateFetch) &&
+            (identical(other.lastBackupAt, lastBackupAt) ||
+                other.lastBackupAt == lastBackupAt));
   }
 
   @override
@@ -145,12 +154,13 @@ mixin _$AppSettings {
         displayName,
         onboardingComplete,
         schemaBackupVersion,
-        lastExchangeRateFetch
+        lastExchangeRateFetch,
+        lastBackupAt
       ]);
 
   @override
   String toString() {
-    return 'AppSettings(homeCurrency: $homeCurrency, theme: $theme, colorSchemeMode: $colorSchemeMode, colorSeed: $colorSeed, animationsEnabled: $animationsEnabled, numberDecimalSeparator: $numberDecimalSeparator, numberThousandsGrouping: $numberThousandsGrouping, currencySymbolPlacement: $currencySymbolPlacement, currencySymbolSpacing: $currencySymbolSpacing, weekStart: $weekStart, timeFormat: $timeFormat, percentagePrecision: $percentagePrecision, descriptionMaxLength: $descriptionMaxLength, backButtonBehaviour: $backButtonBehaviour, lockTimeoutSeconds: $lockTimeoutSeconds, displayName: $displayName, onboardingComplete: $onboardingComplete, schemaBackupVersion: $schemaBackupVersion, lastExchangeRateFetch: $lastExchangeRateFetch)';
+    return 'AppSettings(homeCurrency: $homeCurrency, theme: $theme, colorSchemeMode: $colorSchemeMode, colorSeed: $colorSeed, animationsEnabled: $animationsEnabled, numberDecimalSeparator: $numberDecimalSeparator, numberThousandsGrouping: $numberThousandsGrouping, currencySymbolPlacement: $currencySymbolPlacement, currencySymbolSpacing: $currencySymbolSpacing, weekStart: $weekStart, timeFormat: $timeFormat, percentagePrecision: $percentagePrecision, descriptionMaxLength: $descriptionMaxLength, backButtonBehaviour: $backButtonBehaviour, lockTimeoutSeconds: $lockTimeoutSeconds, displayName: $displayName, onboardingComplete: $onboardingComplete, schemaBackupVersion: $schemaBackupVersion, lastExchangeRateFetch: $lastExchangeRateFetch, lastBackupAt: $lastBackupAt)';
   }
 }
 
@@ -179,7 +189,8 @@ abstract mixin class $AppSettingsCopyWith<$Res> {
       String? displayName,
       bool onboardingComplete,
       int schemaBackupVersion,
-      int? lastExchangeRateFetch});
+      int? lastExchangeRateFetch,
+      int? lastBackupAt});
 }
 
 /// @nodoc
@@ -213,6 +224,7 @@ class _$AppSettingsCopyWithImpl<$Res> implements $AppSettingsCopyWith<$Res> {
     Object? onboardingComplete = null,
     Object? schemaBackupVersion = null,
     Object? lastExchangeRateFetch = freezed,
+    Object? lastBackupAt = freezed,
   }) {
     return _then(_self.copyWith(
       homeCurrency: null == homeCurrency
@@ -290,6 +302,10 @@ class _$AppSettingsCopyWithImpl<$Res> implements $AppSettingsCopyWith<$Res> {
       lastExchangeRateFetch: freezed == lastExchangeRateFetch
           ? _self.lastExchangeRateFetch
           : lastExchangeRateFetch // ignore: cast_nullable_to_non_nullable
+              as int?,
+      lastBackupAt: freezed == lastBackupAt
+          ? _self.lastBackupAt
+          : lastBackupAt // ignore: cast_nullable_to_non_nullable
               as int?,
     ));
   }
@@ -407,7 +423,8 @@ extension AppSettingsPatterns on AppSettings {
             String? displayName,
             bool onboardingComplete,
             int schemaBackupVersion,
-            int? lastExchangeRateFetch)?
+            int? lastExchangeRateFetch,
+            int? lastBackupAt)?
         $default, {
     required TResult orElse(),
   }) {
@@ -433,7 +450,8 @@ extension AppSettingsPatterns on AppSettings {
             _that.displayName,
             _that.onboardingComplete,
             _that.schemaBackupVersion,
-            _that.lastExchangeRateFetch);
+            _that.lastExchangeRateFetch,
+            _that.lastBackupAt);
       case _:
         return orElse();
     }
@@ -473,7 +491,8 @@ extension AppSettingsPatterns on AppSettings {
             String? displayName,
             bool onboardingComplete,
             int schemaBackupVersion,
-            int? lastExchangeRateFetch)
+            int? lastExchangeRateFetch,
+            int? lastBackupAt)
         $default,
   ) {
     final _that = this;
@@ -498,7 +517,8 @@ extension AppSettingsPatterns on AppSettings {
             _that.displayName,
             _that.onboardingComplete,
             _that.schemaBackupVersion,
-            _that.lastExchangeRateFetch);
+            _that.lastExchangeRateFetch,
+            _that.lastBackupAt);
       case _:
         throw StateError('Unexpected subclass');
     }
@@ -537,7 +557,8 @@ extension AppSettingsPatterns on AppSettings {
             String? displayName,
             bool onboardingComplete,
             int schemaBackupVersion,
-            int? lastExchangeRateFetch)?
+            int? lastExchangeRateFetch,
+            int? lastBackupAt)?
         $default,
   ) {
     final _that = this;
@@ -562,7 +583,8 @@ extension AppSettingsPatterns on AppSettings {
             _that.displayName,
             _that.onboardingComplete,
             _that.schemaBackupVersion,
-            _that.lastExchangeRateFetch);
+            _that.lastExchangeRateFetch,
+            _that.lastBackupAt);
       case _:
         return null;
     }
@@ -591,7 +613,8 @@ class _AppSettings implements AppSettings {
       this.displayName,
       this.onboardingComplete = false,
       this.schemaBackupVersion = 1,
-      this.lastExchangeRateFetch});
+      this.lastExchangeRateFetch,
+      this.lastBackupAt});
 
   /// ISO 4217 home currency code; set during onboarding.
   @override
@@ -680,6 +703,14 @@ class _AppSettings implements AppSettings {
   @override
   final int? lastExchangeRateFetch;
 
+  /// Unix epoch of the last successful local backup export.
+  ///
+  /// Written by [BackupService] on successful ZIP export (T-188, SET-07).
+  /// Read by HOME-05 to determine whether to show the backup reminder badge.
+  /// Null when no backup has ever been made.
+  @override
+  final int? lastBackupAt;
+
   /// Create a copy of AppSettings
   /// with the given fields replaced by the non-null parameter values.
   @override
@@ -731,7 +762,9 @@ class _AppSettings implements AppSettings {
             (identical(other.schemaBackupVersion, schemaBackupVersion) ||
                 other.schemaBackupVersion == schemaBackupVersion) &&
             (identical(other.lastExchangeRateFetch, lastExchangeRateFetch) ||
-                other.lastExchangeRateFetch == lastExchangeRateFetch));
+                other.lastExchangeRateFetch == lastExchangeRateFetch) &&
+            (identical(other.lastBackupAt, lastBackupAt) ||
+                other.lastBackupAt == lastBackupAt));
   }
 
   @override
@@ -755,12 +788,13 @@ class _AppSettings implements AppSettings {
         displayName,
         onboardingComplete,
         schemaBackupVersion,
-        lastExchangeRateFetch
+        lastExchangeRateFetch,
+        lastBackupAt
       ]);
 
   @override
   String toString() {
-    return 'AppSettings(homeCurrency: $homeCurrency, theme: $theme, colorSchemeMode: $colorSchemeMode, colorSeed: $colorSeed, animationsEnabled: $animationsEnabled, numberDecimalSeparator: $numberDecimalSeparator, numberThousandsGrouping: $numberThousandsGrouping, currencySymbolPlacement: $currencySymbolPlacement, currencySymbolSpacing: $currencySymbolSpacing, weekStart: $weekStart, timeFormat: $timeFormat, percentagePrecision: $percentagePrecision, descriptionMaxLength: $descriptionMaxLength, backButtonBehaviour: $backButtonBehaviour, lockTimeoutSeconds: $lockTimeoutSeconds, displayName: $displayName, onboardingComplete: $onboardingComplete, schemaBackupVersion: $schemaBackupVersion, lastExchangeRateFetch: $lastExchangeRateFetch)';
+    return 'AppSettings(homeCurrency: $homeCurrency, theme: $theme, colorSchemeMode: $colorSchemeMode, colorSeed: $colorSeed, animationsEnabled: $animationsEnabled, numberDecimalSeparator: $numberDecimalSeparator, numberThousandsGrouping: $numberThousandsGrouping, currencySymbolPlacement: $currencySymbolPlacement, currencySymbolSpacing: $currencySymbolSpacing, weekStart: $weekStart, timeFormat: $timeFormat, percentagePrecision: $percentagePrecision, descriptionMaxLength: $descriptionMaxLength, backButtonBehaviour: $backButtonBehaviour, lockTimeoutSeconds: $lockTimeoutSeconds, displayName: $displayName, onboardingComplete: $onboardingComplete, schemaBackupVersion: $schemaBackupVersion, lastExchangeRateFetch: $lastExchangeRateFetch, lastBackupAt: $lastBackupAt)';
   }
 }
 
@@ -791,7 +825,8 @@ abstract mixin class _$AppSettingsCopyWith<$Res>
       String? displayName,
       bool onboardingComplete,
       int schemaBackupVersion,
-      int? lastExchangeRateFetch});
+      int? lastExchangeRateFetch,
+      int? lastBackupAt});
 }
 
 /// @nodoc
@@ -825,6 +860,7 @@ class __$AppSettingsCopyWithImpl<$Res> implements _$AppSettingsCopyWith<$Res> {
     Object? onboardingComplete = null,
     Object? schemaBackupVersion = null,
     Object? lastExchangeRateFetch = freezed,
+    Object? lastBackupAt = freezed,
   }) {
     return _then(_AppSettings(
       homeCurrency: null == homeCurrency
@@ -902,6 +938,10 @@ class __$AppSettingsCopyWithImpl<$Res> implements _$AppSettingsCopyWith<$Res> {
       lastExchangeRateFetch: freezed == lastExchangeRateFetch
           ? _self.lastExchangeRateFetch
           : lastExchangeRateFetch // ignore: cast_nullable_to_non_nullable
+              as int?,
+      lastBackupAt: freezed == lastBackupAt
+          ? _self.lastBackupAt
+          : lastBackupAt // ignore: cast_nullable_to_non_nullable
               as int?,
     ));
   }

--- a/lib/domain/repositories/i_app_settings_repository.dart
+++ b/lib/domain/repositories/i_app_settings_repository.dart
@@ -31,6 +31,7 @@ class AppSettingsPatch {
     this.displayName,
     this.onboardingComplete,
     this.lastExchangeRateFetch,
+    this.lastBackupAt,
   });
 
   /// ISO 4217 home currency code.
@@ -86,6 +87,11 @@ class AppSettingsPatch {
 
   /// Unix epoch of the last successful exchange rate fetch.
   final int? lastExchangeRateFetch;
+
+  /// Unix epoch of the last successful local backup export.
+  ///
+  /// Written after a successful ZIP export (T-188, SET-07).
+  final int? lastBackupAt;
 }
 
 /// Contract for all AppSettings data-access operations.

--- a/lib/domain/usecases/installment/close_installment_plan_use_case.dart
+++ b/lib/domain/usecases/installment/close_installment_plan_use_case.dart
@@ -1,23 +1,146 @@
 // lib/domain/usecases/installment/close_installment_plan_use_case.dart
 //
-// Use case: close an installment plan early.
+// Use case: close an installment plan early (INST-03, T-135).
+//
+// Flow (PRD §5.2.8.3):
+//   1. Load the template by [id] — reject if already archived.
+//   2. Cancel all pending occurrences via [IInstallmentPlanRepository.closeEarly].
+//   3. Archive the template (status → archived, archivedReason → earlyClose)
+//      via [IRecurringTemplateRepository.update].
+//   4. Optionally update [totalConfiguredMinor] = [newTotalMinor] when the
+//      caller chooses "Update target" after mismatch check (TC-021).
+//
+// Mismatch handling (PRD §5.2.8.3 step 4):
+//   - The mismatch check and UI prompt happen in the presentation layer.
+//   - This use case receives [updateTotalOnEarlyClose]: when true, it updates
+//     the plan's [totalConfiguredMinor] to [newTotalMinor].
+//
+// Returns:
+//   - [Ok(null)]                    on success.
+//   - [Err(BusinessRuleFailure)]    when the template is already archived.
+//   - [Err(NotFoundFailure)]        when no template row exists for [id].
+//   - [Err(DatabaseFailure)]        when a repository write fails.
+//
+// Test cases (see test/unit/domain/usecases/close_installment_plan_use_case_test.dart):
+//   T-144.1  no-final-payment path: pending occurrences cancelled, template archived
+//   T-144.2  updateTotalOnEarlyClose=true updates totalConfiguredMinor
+//   T-144.3  already-archived template → Err(BusinessRuleFailure)
+//   T-144.4  non-existent template → Err(NotFoundFailure)
+//   T-144.5  closeEarly repository failure → Err(DatabaseFailure) propagated
 
+import 'package:variance/domain/core/failure.dart';
 import 'package:variance/domain/core/result.dart';
+import 'package:variance/domain/entities/installment_plan.dart';
+import 'package:variance/domain/entities/recurring_template.dart';
 import 'package:variance/domain/repositories/i_installment_plan_repository.dart';
+import 'package:variance/domain/repositories/i_recurring_template_repository.dart';
+
+/// Input parameters for [CloseInstallmentPlanUseCase].
+class CloseInstallmentPlanInput {
+  /// Creates a [CloseInstallmentPlanInput].
+  ///
+  /// Parameters:
+  /// - [id]: UUID of the installment template to close.
+  /// - [updateTotalOnEarlyClose]: When true, updates [installment_plans.total_configured_minor]
+  ///   to [newTotalMinor]. Used when the user chooses "Update target" after mismatch prompt.
+  /// - [newTotalMinor]: The running total to store as the new target. Required when
+  ///   [updateTotalOnEarlyClose] is true.
+  const CloseInstallmentPlanInput({
+    required this.id,
+    this.updateTotalOnEarlyClose = false,
+    this.newTotalMinor,
+  });
+
+  /// UUID of the installment template to close.
+  final String id;
+
+  /// When true, overwrites [total_configured_minor] with [newTotalMinor].
+  final bool updateTotalOnEarlyClose;
+
+  /// New total in minor units; used when [updateTotalOnEarlyClose] is true.
+  final int? newTotalMinor;
+}
 
 /// Closes the installment plan identified by [id] early.
 ///
 /// Cancels all pending installment occurrences and archives the template.
+/// Optionally updates [totalConfiguredMinor] if the user chooses to align
+/// the target to the actual running total (TC-021).
 class CloseInstallmentPlanUseCase {
-  const CloseInstallmentPlanUseCase(this._repository);
+  /// Creates a [CloseInstallmentPlanUseCase].
+  ///
+  /// Parameters:
+  /// - [planRepository]: Repository for installment plan operations.
+  /// - [templateRepository]: Repository for recurring template operations.
+  const CloseInstallmentPlanUseCase({
+    required IInstallmentPlanRepository planRepository,
+    required IRecurringTemplateRepository templateRepository,
+  })  : _planRepository = planRepository,
+        _templateRepository = templateRepository;
 
-  // ignore: unused_field
-  final IInstallmentPlanRepository _repository;
+  final IInstallmentPlanRepository _planRepository;
+  final IRecurringTemplateRepository _templateRepository;
 
-  /// Executes the use case.
-  Future<Result<void>> call(String id) {
-    throw UnimplementedError(
-      'CloseInstallmentPlanUseCase.call is not implemented',
+  /// Executes the close use case.
+  ///
+  /// Returns [Ok(null)] on success. Returns [Err] on validation or DB failure.
+  ///
+  /// Parameters:
+  /// - [input]: Close parameters including the template [id] and optional
+  ///   total update.
+  Future<Result<void>> call(CloseInstallmentPlanInput input) async {
+    // 1. Load the current template to verify it is eligible to be closed.
+    final template = await _templateRepository.watchById(input.id).first;
+
+    if (template == null) {
+      return const Err(NotFoundFailure('Installment template not found'));
+    }
+
+    // Guard: already-archived templates cannot be closed again.
+    if (template.status == RecurringTemplateStatus.archived) {
+      return const Err(
+        BusinessRuleFailure(
+          'Template is already archived and cannot be closed again',
+        ),
+      );
+    }
+
+    // 2. Cancel all pending occurrences.
+    final closeResult = await _planRepository.closeEarly(input.id);
+    if (closeResult case Err(:final failure)) {
+      return Err(failure);
+    }
+
+    // 3. Archive the template.
+    final now = DateTime.now().millisecondsSinceEpoch ~/ 1000;
+    final archived = template.copyWith(
+      status: RecurringTemplateStatus.archived,
+      archivedAt: now,
+      archivedReason: ArchivedReason.earlyClose,
     );
+    final archiveResult = await _templateRepository.update(archived);
+    if (archiveResult case Err(:final failure)) {
+      return Err(failure);
+    }
+
+    // 4. Optionally update totalConfiguredMinor to match running total (TC-021).
+    if (input.updateTotalOnEarlyClose && input.newTotalMinor != null) {
+      // Read the current plan to preserve fields other than totalConfiguredMinor.
+      final plan = await _planRepository.watchById(input.id).first;
+      if (plan != null) {
+        final updatedPlan = InstallmentPlan(
+          templateId: plan.templateId,
+          totalConfiguredMinor: input.newTotalMinor!,
+          numberOfInstallments: plan.numberOfInstallments,
+          createdAt: plan.createdAt,
+        );
+        final updateResult = await _planRepository.update(updatedPlan);
+        if (updateResult case Err(:final failure)) {
+          return Err(failure);
+        }
+      }
+    }
+
+    return const Ok(null);
   }
 }

--- a/lib/domain/usecases/installment/create_installment_plan_use_case.dart
+++ b/lib/domain/usecases/installment/create_installment_plan_use_case.dart
@@ -360,17 +360,15 @@ class CreateInstallmentPlanUseCase {
     // by computing start of period (numberOfInstallments), which equals:
     //   startEpoch + numberOfInstallments × recurrenceN × unit_length
     return switch (recurrenceUnit) {
-      RecurrenceUnit.day => startEpochSeconds +
-          (numberOfInstallments * recurrenceN * 86400),
-      RecurrenceUnit.week => startEpochSeconds +
-          (numberOfInstallments * recurrenceN * 7 * 86400),
+      RecurrenceUnit.day =>
+        startEpochSeconds + (numberOfInstallments * recurrenceN * 86400),
+      RecurrenceUnit.week =>
+        startEpochSeconds + (numberOfInstallments * recurrenceN * 7 * 86400),
       // For month/year, use PeriodCalculator.compute to find the period
       // containing a reference point exactly (numberOfInstallments * period)
       // after start, then return that period's end. We do this by computing
       // the nth period's end via a reference-period lookup trick.
-      RecurrenceUnit.month ||
-      RecurrenceUnit.year =>
-        _computeVariableEndDate(
+      RecurrenceUnit.month || RecurrenceUnit.year => _computeVariableEndDate(
           startEpochSeconds: startEpochSeconds,
           recurrenceN: recurrenceN,
           recurrenceUnit: recurrenceUnit,
@@ -492,13 +490,10 @@ class CreateInstallmentPlanUseCase {
     required int index,
   }) {
     return switch (recurrenceUnit) {
-      RecurrenceUnit.day =>
-        startEpochSeconds + (index * recurrenceN * 86400),
+      RecurrenceUnit.day => startEpochSeconds + (index * recurrenceN * 86400),
       RecurrenceUnit.week =>
         startEpochSeconds + (index * recurrenceN * 7 * 86400),
-      RecurrenceUnit.month ||
-      RecurrenceUnit.year =>
-        _scheduledVariableDate(
+      RecurrenceUnit.month || RecurrenceUnit.year => _scheduledVariableDate(
           startEpochSeconds: startEpochSeconds,
           recurrenceN: recurrenceN,
           recurrenceUnit: recurrenceUnit,
@@ -524,8 +519,9 @@ class CreateInstallmentPlanUseCase {
       RecurrenceUnit.year => recurrenceN * 365 * 86400,
       _ => throw StateError('Only month/year handled here'),
     };
-    final referenceEpoch =
-        startEpochSeconds + (index * avgSecondsPerPeriod) + (avgSecondsPerPeriod ~/ 2);
+    final referenceEpoch = startEpochSeconds +
+        (index * avgSecondsPerPeriod) +
+        (avgSecondsPerPeriod ~/ 2);
 
     final range = _periodCalculator.compute(
       startEpochSeconds: startEpochSeconds,

--- a/lib/infrastructure/backup/backup_service.dart
+++ b/lib/infrastructure/backup/backup_service.dart
@@ -1,0 +1,418 @@
+// lib/infrastructure/backup/backup_service.dart
+//
+// BackupService — export all non-deleted app data to a versioned ZIP archive.
+//
+// ZIP structure (SDS §2.17, TC-054):
+//   variance_backup_YYYYMMDD_HHmmss.zip
+//     ├── manifest.json        — format version, app version, timestamp, schema
+//     ├── variance_export.json — all non-deleted entities (JSON array per table)
+//     └── attachments/         — referenced photo files (missing files skipped)
+//
+// This service is designed to be called from the UI layer via
+// [BackupNotifier]; it runs the DB snapshot inside a Drift transaction to
+// guarantee a consistent read (SDS §2.17.1 mid-write consistency constraint).
+//
+// After a successful export, the caller is responsible for writing
+// `last_backup_at` to app_settings via [AppSettingsNotifier.save].
+//
+// Test cases (see test/infrastructure/backup/backup_service_test.dart):
+//   T-188.1 manifest JSON contains correct fields and values
+//   T-188.2 soft-deleted entities are absent from variance_export.json
+//   T-188.3 missing photo file is skipped without exception
+//   T-188.4 last_backup_at is written on successful export (integration)
+
+import 'dart:convert';
+import 'dart:developer' as dev;
+import 'dart:io';
+
+import 'package:archive/archive_io.dart';
+import 'package:drift/drift.dart' show QueryRow;
+import 'package:package_info_plus/package_info_plus.dart';
+import 'package:path/path.dart' as p;
+import 'package:path_provider/path_provider.dart';
+
+import 'package:variance/data/database/app_database.dart';
+
+// ---------------------------------------------------------------------------
+// Result types
+// ---------------------------------------------------------------------------
+
+/// Result of a backup export attempt.
+sealed class BackupResult {}
+
+/// Backup completed successfully.
+///
+/// [filePath] is the absolute path to the written ZIP archive.
+final class BackupSuccess extends BackupResult {
+  /// Creates a [BackupSuccess] with the written [filePath].
+  BackupSuccess(this.filePath);
+
+  /// Absolute path to the written ZIP archive.
+  final String filePath;
+}
+
+/// Backup failed.
+///
+/// [message] describes the error for display or logging.
+final class BackupFailure extends BackupResult {
+  /// Creates a [BackupFailure] with an error [message].
+  BackupFailure(this.message);
+
+  /// Human-readable failure description.
+  final String message;
+}
+
+// ---------------------------------------------------------------------------
+// BackupService
+// ---------------------------------------------------------------------------
+
+/// Exports all non-deleted app data to a versioned ZIP archive.
+///
+/// Reads all data inside a Drift read-only transaction for snapshot consistency
+/// (SDS §2.17.1). The ZIP is written to [destinationDir] if provided, or falls
+/// back to the platform Downloads directory.
+///
+/// The caller must write `last_backup_at` to [AppSettingsNotifier] after a
+/// [BackupSuccess] result is received — this service does not write settings.
+class BackupService {
+  /// Creates a [BackupService] backed by [database].
+  ///
+  /// Parameters:
+  /// - [database]: The Drift database; used for all read queries.
+  /// - [appVersionResolver]: Optional async function that returns the app
+  ///   version string. Defaults to reading from [PackageInfo]. Override in
+  ///   tests to avoid platform-plugin dependencies.
+  const BackupService(
+    this._database, {
+    Future<String> Function()? appVersionResolver,
+  }) : _appVersionResolver = appVersionResolver;
+
+  final AppDatabase _database;
+
+  /// Injectable version resolver; null means use the real PackageInfo.
+  final Future<String> Function()? _appVersionResolver;
+
+  // -------------------------------------------------------------------------
+  // Public API
+  // -------------------------------------------------------------------------
+
+  /// Runs the full export and writes the ZIP archive.
+  ///
+  /// Parameters:
+  /// - [destinationDir]: Directory in which to write the ZIP. Falls back to
+  ///   [_resolveDownloadsDir] when null or when the path does not exist.
+  ///
+  /// Returns [BackupSuccess] with the file path on success, or [BackupFailure]
+  /// on any error. Never throws.
+  Future<BackupResult> export({String? destinationDir}) async {
+    try {
+      // 1. Resolve the output directory.
+      final outDir = await _resolveOutputDir(destinationDir);
+      final timestamp = _formatTimestamp(DateTime.now());
+      final zipPath = p.join(outDir, 'variance_backup_$timestamp.zip');
+
+      // 2. Collect all data inside a single DB transaction (snapshot read).
+      late _ExportPayload payload;
+      await _database.transaction(() async {
+        payload = await _collectPayload();
+      });
+
+      // 3. Assemble and write the ZIP archive.
+      final archive = _buildArchive(payload);
+      final encoder = ZipEncoder();
+
+      final outFile = File(zipPath);
+      await outFile.parent.create(recursive: true);
+
+      // Write the archive bytes to disk.
+      final bytes = encoder.encode(archive);
+      await outFile.writeAsBytes(bytes);
+
+      dev.log(
+        'Backup written to $zipPath (${bytes.length} bytes)',
+        name: 'BackupService',
+      );
+
+      return BackupSuccess(zipPath);
+    } on Object catch (e, st) {
+      dev.log('BackupService.export failed: $e',
+          name: 'BackupService', error: e, stackTrace: st);
+      return BackupFailure('Export failed: $e');
+    }
+  }
+
+  // -------------------------------------------------------------------------
+  // Private helpers
+  // -------------------------------------------------------------------------
+
+  /// Collects all data needed for the ZIP from the database.
+  ///
+  /// Must be called inside a Drift [database.transaction] block to ensure a
+  /// consistent snapshot across all table reads.
+  Future<_ExportPayload> _collectPayload() async {
+    // Resolve app version via the injected resolver (production: PackageInfo).
+    final String appVersion;
+    if (_appVersionResolver != null) {
+      appVersion = await _appVersionResolver();
+    } else {
+      // Lazy import to avoid compile-time issues in test environments where
+      // package_info_plus Windows FFI sources fail to compile.
+      appVersion = await _resolveAppVersion();
+    }
+
+    // Read schema_backup_version from app_settings (default 1).
+    final schemaVersionStr =
+        await _database.appSettingsDao.getValue('schema_backup_version');
+    final schemaVersion = int.tryParse(schemaVersionStr ?? '') ?? 1;
+
+    // Read all non-deleted entities from each table.
+    // Tables with is_deleted: accounts, categories, payees, recurring_templates.
+    // Transactions use status='voided' instead of is_deleted (Data Model §11.2).
+    final accounts = await _selectNonDeleted('accounts');
+    final accountDetails = await _database.customSelect(
+      'SELECT * FROM account_details',
+      readsFrom: {},
+    ).get();
+    final categories = await _selectNonDeleted('categories');
+    final tags = await _database.customSelect(
+      'SELECT * FROM tags',
+      readsFrom: {},
+    ).get();
+    final payees = await _selectNonDeleted('payees');
+
+    // Transactions: exclude voided. Include posted, pending, draft.
+    final transactions = await _database.customSelect(
+      "SELECT * FROM transactions WHERE status != 'voided'",
+      readsFrom: {},
+    ).get();
+    final entries = await _database.customSelect(
+      'SELECT * FROM entries',
+      readsFrom: {},
+    ).get();
+    final transactionTags = await _database.customSelect(
+      'SELECT * FROM transaction_tags',
+      readsFrom: {},
+    ).get();
+
+    final currencies = await _database.customSelect(
+      'SELECT * FROM currencies',
+      readsFrom: {},
+    ).get();
+    final exchangeRates = await _database.customSelect(
+      'SELECT * FROM exchange_rates',
+      readsFrom: {},
+    ).get();
+
+    // Attachments — we collect file_path for photo resolution.
+    final attachments = await _database.customSelect(
+      'SELECT * FROM attachments',
+      readsFrom: {},
+    ).get();
+
+    final budgets = await _database.customSelect(
+      'SELECT * FROM budgets',
+      readsFrom: {},
+    ).get();
+    final budgetPeriods = await _database.customSelect(
+      'SELECT * FROM budget_periods',
+      readsFrom: {},
+    ).get();
+
+    final recurringTemplates = await _selectNonDeleted('recurring_templates');
+    final scheduledOccurrences = await _database.customSelect(
+      'SELECT * FROM scheduled_occurrences',
+      readsFrom: {},
+    ).get();
+    final installmentPlans = await _database.customSelect(
+      'SELECT * FROM installment_plans',
+      readsFrom: {},
+    ).get();
+    final installmentOccurrences = await _database.customSelect(
+      'SELECT * FROM installment_occurrences',
+      readsFrom: {},
+    ).get();
+
+    // Resolve photo file paths (relative → absolute via app documents dir).
+    final docsDir = (await getApplicationDocumentsDirectory()).path;
+    final photoPaths = attachments
+        .map((row) {
+          final value = row.data['file_path'];
+          return value is String ? value : null;
+        })
+        .whereType<String>()
+        .map((rel) => p.join(docsDir, rel))
+        .toList();
+
+    return _ExportPayload(
+      appVersion: appVersion,
+      schemaVersion: schemaVersion,
+      createdAt: DateTime.now().toUtc(),
+      entityRows: {
+        'accounts': _rowsToJson(accounts),
+        'account_details': _rowsToJson(accountDetails),
+        'categories': _rowsToJson(categories),
+        'tags': _rowsToJson(tags),
+        'payees': _rowsToJson(payees),
+        'transactions': _rowsToJson(transactions),
+        'entries': _rowsToJson(entries),
+        'transaction_tags': _rowsToJson(transactionTags),
+        'currencies': _rowsToJson(currencies),
+        'exchange_rates': _rowsToJson(exchangeRates),
+        'attachments': _rowsToJson(attachments),
+        'budgets': _rowsToJson(budgets),
+        'budget_periods': _rowsToJson(budgetPeriods),
+        'recurring_templates': _rowsToJson(recurringTemplates),
+        'scheduled_occurrences': _rowsToJson(scheduledOccurrences),
+        'installment_plans': _rowsToJson(installmentPlans),
+        'installment_occurrences': _rowsToJson(installmentOccurrences),
+      },
+      photoPaths: photoPaths,
+    );
+  }
+
+  /// Queries [tableName] filtering out soft-deleted rows (`is_deleted = 1`).
+  Future<List<QueryRow>> _selectNonDeleted(String tableName) {
+    return _database.customSelect(
+      'SELECT * FROM $tableName WHERE is_deleted = 0',
+      readsFrom: {},
+    ).get();
+  }
+
+  /// Converts a list of [QueryRow]s to a list of JSON-serialisable maps.
+  List<Map<String, dynamic>> _rowsToJson(List<QueryRow> rows) {
+    return rows.map((row) {
+      // QueryRow.data is Map<String, dynamic> — values are SQLite primitives
+      // (int, double, String, Uint8List, null). We convert Uint8List to a
+      // base64-encoded string for JSON compatibility (e.g. encrypted fields).
+      final Map<String, dynamic> result = {};
+      for (final entry in row.data.entries) {
+        final value = entry.value;
+        if (value is List<int>) {
+          result[entry.key] = base64Encode(value);
+        } else {
+          result[entry.key] = value;
+        }
+      }
+      return result;
+    }).toList();
+  }
+
+  /// Builds the in-memory [Archive] with manifest, export JSON, and photos.
+  Archive _buildArchive(_ExportPayload payload) {
+    final archive = Archive();
+
+    // --- manifest.json (SDS §2.17.1) ---
+    final manifest = {
+      'backup_format_version': 1,
+      'app_version': payload.appVersion,
+      'created_at': payload.createdAt.toIso8601String(),
+      'schema_version': payload.schemaVersion,
+    };
+    final manifestBytes = utf8.encode(jsonEncode(manifest));
+    archive.addFile(
+      ArchiveFile('manifest.json', manifestBytes.length, manifestBytes),
+    );
+
+    // --- variance_export.json ---
+    final exportBytes = utf8.encode(
+      jsonEncode({'export_version': 1, 'tables': payload.entityRows}),
+    );
+    archive.addFile(
+      ArchiveFile('variance_export.json', exportBytes.length, exportBytes),
+    );
+
+    // --- Photos (skip missing files, log warning) ---
+    for (final photoPath in payload.photoPaths) {
+      final file = File(photoPath);
+      if (!file.existsSync()) {
+        dev.log(
+          'BackupService: photo missing, skipping — $photoPath',
+          name: 'BackupService',
+        );
+        continue;
+      }
+      final photoBytes = file.readAsBytesSync();
+      final archiveName = p.join('attachments', p.basename(photoPath));
+      archive.addFile(
+        ArchiveFile(archiveName, photoBytes.length, photoBytes),
+      );
+    }
+
+    return archive;
+  }
+
+  /// Resolves the output directory.
+  ///
+  /// Uses [dir] if provided and accessible. Falls back to the platform
+  /// Downloads directory, then app external storage.
+  Future<String> _resolveOutputDir(String? dir) async {
+    if (dir != null && dir.isNotEmpty) {
+      final d = Directory(dir);
+      if (d.existsSync()) return dir;
+    }
+    // Fallback: external storage or app documents dir.
+    final downloadsPath = await _resolveDownloadsDir();
+    return downloadsPath;
+  }
+
+  /// Attempts to resolve a writable Downloads directory.
+  ///
+  /// Returns the app external storage path on Android if the standard
+  /// Downloads directory is not accessible.
+  Future<String> _resolveDownloadsDir() async {
+    // Standard Android external storage (getExternalStorageDirectory covers
+    // the app-private external directory; no WRITE_EXTERNAL_STORAGE needed).
+    final externalDir = await getExternalStorageDirectory();
+    if (externalDir != null) {
+      return externalDir.path;
+    }
+    // Last resort: app documents directory.
+    final docsDir = await getApplicationDocumentsDirectory();
+    return docsDir.path;
+  }
+
+  /// Reads the app version string from [PackageInfo.fromPlatform].
+  ///
+  /// Only called in production (non-test) paths. Tests inject a version
+  /// resolver via the constructor to avoid platform-plugin dependencies.
+  Future<String> _resolveAppVersion() async {
+    final info = await PackageInfo.fromPlatform();
+    return info.version;
+  }
+
+  /// Formats a [DateTime] as `YYYYMMDDHHmmss` for the file name.
+  String _formatTimestamp(DateTime dt) {
+    final y = dt.year.toString().padLeft(4, '0');
+    final mo = dt.month.toString().padLeft(2, '0');
+    final d = dt.day.toString().padLeft(2, '0');
+    final h = dt.hour.toString().padLeft(2, '0');
+    final mi = dt.minute.toString().padLeft(2, '0');
+    final s = dt.second.toString().padLeft(2, '0');
+    return '$y$mo$d$h$mi$s';
+  }
+}
+
+// ---------------------------------------------------------------------------
+// Internal data holder
+// ---------------------------------------------------------------------------
+
+/// Internal payload assembled from a single DB snapshot transaction.
+class _ExportPayload {
+  const _ExportPayload({
+    required this.appVersion,
+    required this.schemaVersion,
+    required this.createdAt,
+    required this.entityRows,
+    required this.photoPaths,
+  });
+
+  final String appVersion;
+  final int schemaVersion;
+  final DateTime createdAt;
+
+  /// Map of table name → list of serialised row maps.
+  final Map<String, List<Map<String, dynamic>>> entityRows;
+
+  /// Absolute file paths to attached photos.
+  final List<String> photoPaths;
+}

--- a/lib/presentation/features/settings/backup/backup_data_screen.dart
+++ b/lib/presentation/features/settings/backup/backup_data_screen.dart
@@ -1,0 +1,307 @@
+// lib/presentation/features/settings/backup/backup_data_screen.dart
+//
+// BackupDataScreen — settings screen for triggering a local data backup (T-187).
+//
+// Route: /settings/backup
+//
+// Functionality:
+//   - Shows last backup timestamp from app_settings.last_backup_at.
+//   - "Backup Now" button launches the Android SAF directory picker via
+//     FilePicker.getDirectoryPath(). On selection, calls BackupNotifier.runBackup.
+//   - Falls back to app external storage if SAF returns null or throws.
+//   - Shows CircularProgressIndicator during export.
+//   - Shows success SnackBar with the output file path on completion.
+//   - Shows error SnackBar on failure.
+//
+// Spec: T-187, SET-07, SDS §2.17
+//
+// Test cases (see test/presentation/features/settings/backup/
+//             backup_data_screen_test.dart):
+//   T-187.W1 loaded state with no previous backup shows 'Never backed up'
+//   T-187.W2 loaded state with previous backup shows formatted timestamp
+//   T-187.W3 in-progress state shows CircularProgressIndicator
+//   T-187.W4 success state shows success snackbar message
+//   T-187.W5 error state shows error snackbar message
+
+import 'package:file_picker/file_picker.dart';
+import 'package:flutter/material.dart';
+import 'package:flutter_riverpod/flutter_riverpod.dart';
+import 'package:intl/intl.dart';
+
+import 'package:variance/presentation/features/settings/backup/backup_providers.dart';
+
+/// Settings screen for the local data backup feature.
+///
+/// Displays the last backup timestamp and a button to trigger a new export.
+/// Integrates with the Android SAF file picker for destination selection.
+class BackupDataScreen extends ConsumerStatefulWidget {
+  /// Creates a [BackupDataScreen].
+  const BackupDataScreen({super.key});
+
+  @override
+  ConsumerState<BackupDataScreen> createState() => _BackupDataScreenState();
+}
+
+class _BackupDataScreenState extends ConsumerState<BackupDataScreen> {
+  // Track the last state we already showed a SnackBar for to prevent duplicate
+  // SnackBars on rebuilds.
+  BackupState? _lastHandledState;
+
+  @override
+  Widget build(BuildContext context) {
+    final backupAsync = ref.watch(backupProvider);
+
+    // Show SnackBar feedback on success / failure transitions.
+    ref.listen<AsyncValue<BackupState>>(
+      backupProvider,
+      (_, AsyncValue<BackupState> next) {
+        if (!mounted) return;
+        final value = next.value;
+        if (value == null || identical(value, _lastHandledState)) return;
+
+        if (value is BackupDoneState) {
+          _lastHandledState = value;
+          ScaffoldMessenger.of(context).showSnackBar(
+            SnackBar(
+              content: Text('Backup saved to ${value.filePath}'),
+              backgroundColor: Theme.of(context).colorScheme.primaryContainer,
+            ),
+          );
+        } else if (value is BackupFailedState) {
+          _lastHandledState = value;
+          ScaffoldMessenger.of(context).showSnackBar(
+            SnackBar(
+              content: Text('Backup failed: ${value.message}'),
+              backgroundColor: Theme.of(context).colorScheme.errorContainer,
+            ),
+          );
+        }
+      },
+    );
+
+    return Scaffold(
+      appBar: AppBar(
+        title: const Text('Backup & Data'),
+      ),
+      body: backupAsync.when(
+        loading: () => const Center(child: CircularProgressIndicator()),
+        error: (Object e, _) => Center(child: Text('Error: $e')),
+        data: (BackupState backupState) => _BackupBody(
+          backupState: backupState,
+          onBackupTap: _handleBackupTap,
+        ),
+      ),
+    );
+  }
+
+  Future<void> _handleBackupTap() async {
+    // Launch SAF directory picker (static API in file_picker 11.x).
+    String? selectedDir;
+    try {
+      selectedDir = await FilePicker.getDirectoryPath();
+    } on Object {
+      // SAF unavailable or user cancelled; BackupService falls back to
+      // external storage / documents directory.
+      selectedDir = null;
+    }
+
+    if (!mounted) return;
+    await ref
+        .read(backupProvider.notifier)
+        .runBackup(destinationDir: selectedDir);
+  }
+}
+
+// ---------------------------------------------------------------------------
+// Body widget
+// ---------------------------------------------------------------------------
+
+/// The scrollable content body of [BackupDataScreen].
+class _BackupBody extends StatelessWidget {
+  const _BackupBody({
+    required this.backupState,
+    required this.onBackupTap,
+  });
+
+  final BackupState backupState;
+  final VoidCallback onBackupTap;
+
+  @override
+  Widget build(BuildContext context) {
+    return ListView(
+      padding: const EdgeInsets.all(16),
+      children: [
+        _LastBackupCard(backupState: backupState),
+        const SizedBox(height: 24),
+        _BackupActionSection(
+          backupState: backupState,
+          onBackupTap: onBackupTap,
+        ),
+      ],
+    );
+  }
+}
+
+// ---------------------------------------------------------------------------
+// Last backup info card
+// ---------------------------------------------------------------------------
+
+/// Card displaying when the last backup was made (or 'Never backed up').
+class _LastBackupCard extends StatelessWidget {
+  const _LastBackupCard({required this.backupState});
+
+  final BackupState backupState;
+
+  @override
+  Widget build(BuildContext context) {
+    final theme = Theme.of(context);
+
+    final int? lastBackupAt = backupState is BackupIdleState
+        ? (backupState as BackupIdleState).lastBackupAt
+        : null;
+
+    final String lastBackupLabel;
+    if (lastBackupAt != null) {
+      final dt = DateTime.fromMillisecondsSinceEpoch(lastBackupAt * 1000);
+      lastBackupLabel = DateFormat('dd MMM yyyy, HH:mm').format(dt);
+    } else {
+      lastBackupLabel = 'Never backed up';
+    }
+
+    return Card.filled(
+      color: theme.colorScheme.surfaceContainerLow,
+      child: Padding(
+        padding: const EdgeInsets.all(16),
+        child: Row(
+          children: [
+            Icon(
+              Icons.history,
+              color: theme.colorScheme.onSurfaceVariant,
+            ),
+            const SizedBox(width: 12),
+            Expanded(
+              child: Column(
+                crossAxisAlignment: CrossAxisAlignment.start,
+                children: [
+                  Text(
+                    'Last backup',
+                    style: theme.textTheme.labelMedium?.copyWith(
+                      color: theme.colorScheme.onSurfaceVariant,
+                    ),
+                  ),
+                  const SizedBox(height: 2),
+                  Text(
+                    lastBackupLabel,
+                    style: theme.textTheme.bodyMedium?.copyWith(
+                      color: theme.colorScheme.onSurface,
+                    ),
+                  ),
+                ],
+              ),
+            ),
+          ],
+        ),
+      ),
+    );
+  }
+}
+
+// ---------------------------------------------------------------------------
+// Backup action section
+// ---------------------------------------------------------------------------
+
+/// The backup button and in-progress indicator section.
+class _BackupActionSection extends StatelessWidget {
+  const _BackupActionSection({
+    required this.backupState,
+    required this.onBackupTap,
+  });
+
+  final BackupState backupState;
+  final VoidCallback onBackupTap;
+
+  @override
+  Widget build(BuildContext context) {
+    final theme = Theme.of(context);
+    final isInProgress = backupState is BackupInProgressState;
+
+    return Column(
+      crossAxisAlignment: CrossAxisAlignment.stretch,
+      children: [
+        Text(
+          'Create a local backup of all your data. The backup file will be '
+          'saved to the location you choose.',
+          style: theme.textTheme.bodyMedium?.copyWith(
+            color: theme.colorScheme.onSurfaceVariant,
+          ),
+        ),
+        const SizedBox(height: 16),
+        if (isInProgress) ...[
+          const Center(child: CircularProgressIndicator()),
+          const SizedBox(height: 8),
+          Center(
+            child: Text(
+              'Creating backup…',
+              style: theme.textTheme.bodySmall?.copyWith(
+                color: theme.colorScheme.onSurfaceVariant,
+              ),
+            ),
+          ),
+        ] else
+          FilledButton.icon(
+            onPressed: onBackupTap,
+            icon: const Icon(Icons.backup_outlined),
+            label: const Text('Backup Now'),
+          ),
+        const SizedBox(height: 16),
+        const _InfoRow(
+          icon: Icons.lock_outline,
+          text: 'Your data is exported to a local ZIP file. '
+              'No data is sent to any server.',
+        ),
+        const SizedBox(height: 8),
+        const _InfoRow(
+          icon: Icons.restore_outlined,
+          text:
+              'Import/restore from backup will be available in a future update.',
+        ),
+      ],
+    );
+  }
+}
+
+// ---------------------------------------------------------------------------
+// Info row helper
+// ---------------------------------------------------------------------------
+
+/// A small inline row combining a leading icon with an informational text line.
+class _InfoRow extends StatelessWidget {
+  const _InfoRow({required this.icon, required this.text});
+
+  final IconData icon;
+  final String text;
+
+  @override
+  Widget build(BuildContext context) {
+    final theme = Theme.of(context);
+    return Row(
+      crossAxisAlignment: CrossAxisAlignment.start,
+      children: [
+        Icon(
+          icon,
+          size: 16,
+          color: theme.colorScheme.onSurfaceVariant,
+        ),
+        const SizedBox(width: 8),
+        Expanded(
+          child: Text(
+            text,
+            style: theme.textTheme.bodySmall?.copyWith(
+              color: theme.colorScheme.onSurfaceVariant,
+            ),
+          ),
+        ),
+      ],
+    );
+  }
+}

--- a/lib/presentation/features/settings/backup/backup_providers.dart
+++ b/lib/presentation/features/settings/backup/backup_providers.dart
@@ -1,0 +1,127 @@
+// lib/presentation/features/settings/backup/backup_providers.dart
+//
+// Riverpod providers for the BackupDataScreen (T-187, T-188).
+//
+// Provider graph:
+//   backupServiceProvider (keepAlive)
+//     ← appDatabaseProvider
+//
+//   backupNotifierProvider (AsyncNotifier, auto-dispose)
+//     ← backupServiceProvider
+//     ← appSettingsProvider (to read last_backup_at and write it on success)
+//
+// BackupState models the backup UI state (idle, inProgress, done, failed).
+//
+// Test cases (see test/presentation/features/settings/backup/backup_providers_test.dart):
+//   T-187.1 initial state is BackupIdleState with lastBackupAt from settings
+//   T-187.2 BackupInProgressState emitted during export
+//   T-187.3 BackupDoneState contains file path on success
+//   T-187.4 BackupFailedState on service failure
+//   T-187.5 last_backup_at written to settings on success
+
+import 'package:riverpod_annotation/riverpod_annotation.dart';
+
+import 'package:variance/domain/repositories/i_app_settings_repository.dart';
+import 'package:variance/infrastructure/backup/backup_service.dart' as svc;
+import 'package:variance/presentation/providers/app_settings_providers.dart';
+import 'package:variance/presentation/providers/database_providers.dart';
+
+part 'backup_providers.g.dart';
+
+// ---------------------------------------------------------------------------
+// Backup UI state
+// ---------------------------------------------------------------------------
+
+/// Represents the current state of the backup UI.
+sealed class BackupState {}
+
+/// No backup in progress; shows last backup timestamp (or null if never).
+final class BackupIdleState extends BackupState {
+  /// Creates a [BackupIdleState].
+  ///
+  /// Parameters:
+  /// - [lastBackupAt]: Unix epoch seconds of the last backup, or null.
+  BackupIdleState({this.lastBackupAt});
+
+  /// Unix epoch seconds of the last successful backup, or null if never.
+  final int? lastBackupAt;
+}
+
+/// Backup export is currently running.
+final class BackupInProgressState extends BackupState {}
+
+/// Backup completed successfully.
+final class BackupDoneState extends BackupState {
+  /// Creates a [BackupDoneState] with the archive [filePath].
+  BackupDoneState(this.filePath);
+
+  /// Absolute path to the written ZIP archive.
+  final String filePath;
+}
+
+/// Backup failed.
+final class BackupFailedState extends BackupState {
+  /// Creates a [BackupFailedState] with an error [message].
+  BackupFailedState(this.message);
+
+  /// Human-readable error description.
+  final String message;
+}
+
+// ---------------------------------------------------------------------------
+// BackupService provider
+// ---------------------------------------------------------------------------
+
+/// Provides a singleton [svc.BackupService] backed by the app database.
+@Riverpod(keepAlive: true)
+Future<svc.BackupService> backupService(Ref ref) async {
+  final db = await ref.watch(appDatabaseProvider.future);
+  return svc.BackupService(db);
+}
+
+// ---------------------------------------------------------------------------
+// BackupNotifier
+// ---------------------------------------------------------------------------
+
+/// Manages the backup UI state and triggers export.
+///
+/// Reads [lastBackupAt] from [appSettingsProvider] for the initial idle state.
+///
+/// Call [runBackup] with an optional SAF-selected directory path to begin
+/// export. On success, writes `last_backup_at` to [AppSettingsNotifier].
+@riverpod
+class BackupNotifier extends _$BackupNotifier {
+  @override
+  Future<BackupState> build() async {
+    final settings = await ref.watch(appSettingsProvider.future);
+    return BackupIdleState(lastBackupAt: settings.lastBackupAt);
+  }
+
+  /// Triggers a backup export.
+  ///
+  /// Transitions through [BackupInProgressState] → [BackupDoneState] or
+  /// [BackupFailedState]. On success, writes `last_backup_at` to settings.
+  ///
+  /// Parameters:
+  /// - [destinationDir]: SAF-provided directory path; null uses the default
+  ///   Downloads fallback.
+  Future<void> runBackup({String? destinationDir}) async {
+    state = AsyncData<BackupState>(BackupInProgressState());
+
+    final service = await ref.read(backupServiceProvider.future);
+    final result = await service.export(destinationDir: destinationDir);
+
+    switch (result) {
+      case svc.BackupSuccess(:final filePath):
+        // Record the backup timestamp in app settings.
+        final now = DateTime.now().millisecondsSinceEpoch ~/ 1000;
+        await ref
+            .read(appSettingsProvider.notifier)
+            .save(AppSettingsPatch(lastBackupAt: now));
+        state = AsyncData<BackupState>(BackupDoneState(filePath));
+
+      case svc.BackupFailure(:final message):
+        state = AsyncData<BackupState>(BackupFailedState(message));
+    }
+  }
+}

--- a/lib/presentation/navigation/app_router.dart
+++ b/lib/presentation/navigation/app_router.dart
@@ -57,6 +57,7 @@ import 'package:variance/presentation/features/home/home_screen.dart';
 import 'package:variance/presentation/features/onboarding/onboarding_screen.dart';
 import 'package:variance/presentation/features/settings/appearance/appearance_settings_screen.dart';
 import 'package:variance/presentation/features/settings/appearance/color_scheme_preview_screen.dart';
+import 'package:variance/presentation/features/settings/backup/backup_data_screen.dart';
 import 'package:variance/presentation/features/settings/categories/category_detail_screen.dart';
 import 'package:variance/presentation/features/settings/categories/category_management_screen.dart';
 import 'package:variance/presentation/features/settings/currency/currency_picker_screen.dart';
@@ -568,15 +569,10 @@ GoRouter makeAppRouter(WidgetRef ref) {
                       errorMessage: 'Drafts settings not yet implemented.',
                     ),
                   ),
-                  // /settings/backup — placeholder
+                  // /settings/backup — BackupDataScreen (T-187)
                   GoRoute(
                     path: 'backup',
-                    builder: (context, state) {
-                      // TODO(dev): return BackupRestoreScreen();
-                      return const RouteErrorScreen(
-                        errorMessage: 'Backup & restore not yet implemented.',
-                      );
-                    },
+                    builder: (context, state) => const BackupDataScreen(),
                   ),
                   // /settings/about — placeholder
                   GoRoute(

--- a/pubspec.lock
+++ b/pubspec.lock
@@ -33,6 +33,14 @@ packages:
       url: "https://pub.dev"
     source: hosted
     version: "0.3.2"
+  archive:
+    dependency: "direct main"
+    description:
+      name: archive
+      sha256: a96e8b390886ee8abb49b7bd3ac8df6f451c621619f52a26e815fdcf568959ff
+      url: "https://pub.dev"
+    source: hosted
+    version: "4.0.9"
   args:
     dependency: transitive
     description:
@@ -872,6 +880,22 @@ packages:
       url: "https://pub.dev"
     source: hosted
     version: "2.2.0"
+  package_info_plus:
+    dependency: "direct main"
+    description:
+      name: package_info_plus
+      sha256: "16eee997588c60225bda0488b6dcfac69280a6b7a3cf02c741895dd370a02968"
+      url: "https://pub.dev"
+    source: hosted
+    version: "8.3.1"
+  package_info_plus_platform_interface:
+    dependency: transitive
+    description:
+      name: package_info_plus_platform_interface
+      sha256: "202a487f08836a592a6bd4f901ac69b3a8f146af552bbd14407b6b41e1c3f086"
+      url: "https://pub.dev"
+    source: hosted
+    version: "3.2.1"
   path:
     dependency: "direct main"
     description:
@@ -960,6 +984,14 @@ packages:
       url: "https://pub.dev"
     source: hosted
     version: "1.5.2"
+  posix:
+    dependency: transitive
+    description:
+      name: posix
+      sha256: "185ef7606574f789b40f289c233efa52e96dead518aed988e040a10737febb07"
+      url: "https://pub.dev"
+    source: hosted
+    version: "6.5.0"
   pub_semver:
     dependency: transitive
     description:
@@ -1142,7 +1174,7 @@ packages:
     source: hosted
     version: "0.44.4"
   stack_trace:
-    dependency: transitive
+    dependency: "direct main"
     description:
       name: stack_trace
       sha256: "8b27215b45d22309b5cddda1aa2b19bdfec9df0e765f2de506401c071d38d1b1"

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -78,6 +78,8 @@ dependencies:
   uuid: ^4.5.3
   sqlite3: ^3.3.1
   stack_trace: ^1.12.1
+  archive: ^4.0.9
+  package_info_plus: ^8.0.0
 
 # ---------------------------------------------------------------------------
 # Development dependencies

--- a/test/infrastructure/backup/backup_service_test.dart
+++ b/test/infrastructure/backup/backup_service_test.dart
@@ -1,0 +1,273 @@
+// test/infrastructure/backup/backup_service_test.dart
+//
+// Unit tests for BackupService (T-188).
+//
+// Uses an in-memory AppDatabase — no disk I/O beyond the temp ZIP file,
+// which is written to a system temp directory and cleaned up after each test.
+//
+// BackupService is constructed with an injected [appVersionResolver] to avoid
+// package_info_plus platform-plugin dependencies in tests.
+//
+// Test cases:
+//   T-188.1 manifest JSON contains correct fields and structure
+//   T-188.2 soft-deleted accounts absent from variance_export.json
+//   T-188.3 missing photo file is skipped without exception
+//   T-188.4 variance_export.json contains non-deleted accounts
+//   T-188.5 ZIP contains both manifest.json and variance_export.json
+//   T-188.6 backup file name matches variance_backup_YYYYMMDD_ pattern
+
+import 'dart:convert';
+import 'dart:io';
+
+import 'package:archive/archive_io.dart';
+import 'package:drift/native.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:path/path.dart' as p;
+import 'package:path_provider_platform_interface/path_provider_platform_interface.dart';
+import 'package:plugin_platform_interface/plugin_platform_interface.dart';
+
+import 'package:variance/data/database/app_database.dart';
+import 'package:variance/infrastructure/backup/backup_service.dart';
+
+// ---------------------------------------------------------------------------
+// path_provider mock
+// ---------------------------------------------------------------------------
+
+/// Minimal [PathProviderPlatform] fake that returns a temp directory for all
+/// path queries used by [BackupService].
+class _FakePathProvider extends Fake
+    with MockPlatformInterfaceMixin
+    implements PathProviderPlatform {
+  _FakePathProvider(this.tempDir);
+
+  final String tempDir;
+
+  @override
+  Future<String?> getApplicationDocumentsPath() async => tempDir;
+
+  @override
+  Future<String?> getExternalStoragePath() async => tempDir;
+
+  @override
+  Future<List<String>?> getExternalStoragePaths({
+    StorageDirectory? type,
+  }) async =>
+      null;
+
+  @override
+  Future<String?> getApplicationCachePath() async => tempDir;
+
+  @override
+  Future<String?> getApplicationSupportPath() async => tempDir;
+
+  @override
+  Future<String?> getDownloadsPath() async => tempDir;
+
+  @override
+  Future<String?> getTemporaryPath() async => tempDir;
+
+  @override
+  Future<String?> getLibraryPath() async => null;
+}
+
+// ---------------------------------------------------------------------------
+// Helpers
+// ---------------------------------------------------------------------------
+
+/// Returns a [BackupService] backed by [db] with a stub version resolver.
+BackupService _makeService(AppDatabase db) {
+  return BackupService(
+    db,
+    appVersionResolver: () async => '1.0.0-test',
+  );
+}
+
+/// Inserts a minimal accounts row.
+///
+/// Uses [account_category] (Drift column for account type) and
+/// [initial_balance_minor] as per the actual schema.
+Future<void> _insertAccount(
+  AppDatabase db,
+  String id,
+  String name, {
+  int isDeleted = 0,
+}) async {
+  final now = DateTime.now().millisecondsSinceEpoch ~/ 1000;
+  await db.customStatement(
+    '''
+    INSERT INTO accounts (id, name, account_category, currency_code,
+      initial_balance_minor, is_deleted, created_at, updated_at)
+    VALUES (?, ?, 'savings', 'INR', 0, ?, ?, ?)
+    ''',
+    [id, name, isDeleted, now, now],
+  );
+}
+
+// ---------------------------------------------------------------------------
+// Main
+// ---------------------------------------------------------------------------
+
+void main() {
+  TestWidgetsFlutterBinding.ensureInitialized();
+
+  late AppDatabase db;
+  late Directory tempDir;
+
+  setUp(() async {
+    tempDir = await Directory.systemTemp.createTemp('backup_test_');
+    db = AppDatabase(NativeDatabase.memory());
+
+    // Register fake path provider so BackupService resolves paths correctly.
+    PathProviderPlatform.instance = _FakePathProvider(tempDir.path);
+
+    // Seed schema_backup_version in app_settings.
+    await db.customStatement('PRAGMA foreign_keys = OFF');
+    await db.customStatement(
+      "INSERT OR REPLACE INTO app_settings (key, value, updated_at)"
+      " VALUES ('schema_backup_version', '1', 1700000000)",
+    );
+    await db.customStatement('PRAGMA foreign_keys = ON');
+  });
+
+  tearDown(() async {
+    await db.close();
+    if (tempDir.existsSync()) {
+      tempDir.deleteSync(recursive: true);
+    }
+  });
+
+  // ---- T-188.1 Manifest structure ------------------------------------------
+
+  test('T-188.1 manifest JSON contains required fields', () async {
+    final service = _makeService(db);
+    final result = await service.export(destinationDir: tempDir.path);
+    expect(result, isA<BackupSuccess>());
+
+    final zipPath = (result as BackupSuccess).filePath;
+    final archive = ZipDecoder().decodeBytes(File(zipPath).readAsBytesSync());
+
+    final manifestFile = archive.files.firstWhere(
+      (f) => f.name == 'manifest.json',
+    );
+    final manifest = jsonDecode(utf8.decode(manifestFile.content as List<int>))
+        as Map<String, dynamic>;
+
+    expect(manifest['backup_format_version'], 1);
+    expect(manifest['app_version'], '1.0.0-test');
+    expect(manifest['created_at'], isA<String>());
+    expect(manifest['schema_version'], 1);
+
+    // created_at must be valid ISO 8601 UTC.
+    final createdAt = DateTime.tryParse(manifest['created_at'] as String);
+    expect(createdAt, isNotNull);
+  });
+
+  // ---- T-188.2 Soft-deleted entities excluded --------------------------------
+
+  test('T-188.2 soft-deleted accounts absent from variance_export.json',
+      () async {
+    await db.customStatement('PRAGMA foreign_keys = OFF');
+    await _insertAccount(db, 'acc-active', 'Active Account', isDeleted: 0);
+    await _insertAccount(db, 'acc-deleted', 'Deleted Account', isDeleted: 1);
+    await db.customStatement('PRAGMA foreign_keys = ON');
+
+    final service = _makeService(db);
+    final result = await service.export(destinationDir: tempDir.path);
+    expect(result, isA<BackupSuccess>());
+
+    final zipPath = (result as BackupSuccess).filePath;
+    final archive = ZipDecoder().decodeBytes(File(zipPath).readAsBytesSync());
+
+    final exportFile = archive.files.firstWhere(
+      (f) => f.name == 'variance_export.json',
+    );
+    final export = jsonDecode(utf8.decode(exportFile.content as List<int>))
+        as Map<String, dynamic>;
+
+    final accounts =
+        (export['tables'] as Map<String, dynamic>)['accounts'] as List<dynamic>;
+    final ids = accounts.map((a) => (a as Map)['id']).toList();
+
+    expect(ids, contains('acc-active'));
+    expect(ids, isNot(contains('acc-deleted')));
+  });
+
+  // ---- T-188.3 Missing photo skipped ----------------------------------------
+
+  test('T-188.3 missing photo file skipped without exception', () async {
+    await db.customStatement('PRAGMA foreign_keys = OFF');
+    await db.customStatement(
+      "INSERT INTO attachments (id, transaction_id, file_path,"
+      " file_size_bytes, mime_type, created_at)"
+      " VALUES ('att-1', 'tx-ghost', 'attachments/ghost.jpg', 0,"
+      " 'image/jpeg', 1700000000)",
+    );
+    await db.customStatement('PRAGMA foreign_keys = ON');
+
+    final service = _makeService(db);
+    // Should complete without throwing.
+    final result = await service.export(destinationDir: tempDir.path);
+    expect(result, isA<BackupSuccess>());
+
+    final zipPath = (result as BackupSuccess).filePath;
+    final archive = ZipDecoder().decodeBytes(File(zipPath).readAsBytesSync());
+
+    // Ghost photo must NOT appear in the archive.
+    final names = archive.files.map((f) => f.name).toList();
+    expect(names, isNot(contains('attachments/ghost.jpg')));
+  });
+
+  // ---- T-188.4 Non-deleted entities included ---------------------------------
+
+  test('T-188.4 non-deleted accounts present in variance_export.json',
+      () async {
+    await db.customStatement('PRAGMA foreign_keys = OFF');
+    await _insertAccount(db, 'acc-ok', 'My Account', isDeleted: 0);
+    await db.customStatement('PRAGMA foreign_keys = ON');
+
+    final service = _makeService(db);
+    final result = await service.export(destinationDir: tempDir.path);
+    expect(result, isA<BackupSuccess>());
+
+    final zipPath = (result as BackupSuccess).filePath;
+    final archive = ZipDecoder().decodeBytes(File(zipPath).readAsBytesSync());
+
+    final exportFile = archive.files.firstWhere(
+      (f) => f.name == 'variance_export.json',
+    );
+    final export = jsonDecode(utf8.decode(exportFile.content as List<int>))
+        as Map<String, dynamic>;
+
+    final accounts =
+        (export['tables'] as Map<String, dynamic>)['accounts'] as List<dynamic>;
+    final ids = accounts.map((a) => (a as Map)['id']).toList();
+    expect(ids, contains('acc-ok'));
+  });
+
+  // ---- T-188.5 ZIP structure ------------------------------------------------
+
+  test('T-188.5 ZIP contains manifest.json and variance_export.json', () async {
+    final service = _makeService(db);
+    final result = await service.export(destinationDir: tempDir.path);
+    expect(result, isA<BackupSuccess>());
+
+    final zipPath = (result as BackupSuccess).filePath;
+    final archive = ZipDecoder().decodeBytes(File(zipPath).readAsBytesSync());
+
+    final names = archive.files.map((f) => f.name).toList();
+    expect(names, contains('manifest.json'));
+    expect(names, contains('variance_export.json'));
+  });
+
+  // ---- T-188.6 File name pattern -------------------------------------------
+
+  test('T-188.6 backup file name matches variance_backup_YYYYMMDD_ pattern',
+      () async {
+    final service = _makeService(db);
+    final result = await service.export(destinationDir: tempDir.path);
+    expect(result, isA<BackupSuccess>());
+
+    final fileName = p.basename((result as BackupSuccess).filePath);
+    expect(fileName, matches(RegExp(r'^variance_backup_\d{14}\.zip$')));
+  });
+}

--- a/test/presentation/features/settings/backup/backup_data_screen_test.dart
+++ b/test/presentation/features/settings/backup/backup_data_screen_test.dart
@@ -1,0 +1,178 @@
+// test/presentation/features/settings/backup/backup_data_screen_test.dart
+//
+// Widget tests for BackupDataScreen (T-187).
+//
+// Tests use overridden Riverpod providers to control backup state without
+// invoking the real BackupService or FilePicker.
+//
+// Test cases:
+//   T-187.W1 loaded state with no previous backup shows 'Never backed up'
+//   T-187.W2 loaded state with previous backup shows formatted timestamp
+//   T-187.W3 in-progress state shows CircularProgressIndicator
+//   T-187.W4 success state: SnackBar shown with file path
+//   T-187.W5 error state: SnackBar shown with error message
+//   T-187.W6 screen title is 'Backup & Data'
+//   T-187.W7 'Backup Now' button is visible when idle
+
+import 'dart:async';
+
+import 'package:flutter/material.dart';
+import 'package:flutter_riverpod/flutter_riverpod.dart';
+import 'package:flutter_test/flutter_test.dart';
+
+import 'package:variance/presentation/features/settings/backup/backup_data_screen.dart';
+import 'package:variance/presentation/features/settings/backup/backup_providers.dart';
+
+// ---------------------------------------------------------------------------
+// Fake BackupNotifier
+// ---------------------------------------------------------------------------
+
+/// Fake notifier that starts in [BackupIdleState] and allows direct state
+/// injection for testing.
+class _FakeBackupNotifier extends BackupNotifier {
+  _FakeBackupNotifier(this._initial);
+
+  final BackupState _initial;
+
+  @override
+  Future<BackupState> build() async => _initial;
+
+  /// Drives the state to [newState] for testing state transitions.
+  void driveState(BackupState newState) {
+    state = AsyncData(newState);
+  }
+
+  @override
+  Future<void> runBackup({String? destinationDir}) async {
+    // No-op: tests drive state manually.
+  }
+}
+
+// ---------------------------------------------------------------------------
+// Helpers
+// ---------------------------------------------------------------------------
+
+Widget _buildApp({
+  required BackupState initialState,
+  _FakeBackupNotifier? notifier,
+}) {
+  final fakeNotifier = notifier ?? _FakeBackupNotifier(initialState);
+  return ProviderScope(
+    overrides: [
+      backupProvider.overrideWith(() => fakeNotifier),
+    ],
+    child: const MaterialApp(
+      home: BackupDataScreen(),
+    ),
+  );
+}
+
+// ---------------------------------------------------------------------------
+// Tests
+// ---------------------------------------------------------------------------
+
+void main() {
+  group('BackupDataScreen', () {
+    // ---- T-187.W6 AppBar title -----------------------------------------------
+
+    testWidgets('T-187.W6 screen title is Backup & Data', (tester) async {
+      await tester.pumpWidget(_buildApp(
+        initialState: BackupIdleState(),
+      ));
+      await tester.pump();
+
+      expect(find.text('Backup & Data'), findsOneWidget);
+    });
+
+    // ---- T-187.W1 No previous backup ----------------------------------------
+
+    testWidgets('T-187.W1 no previous backup shows Never backed up',
+        (tester) async {
+      await tester.pumpWidget(_buildApp(
+        initialState: BackupIdleState(lastBackupAt: null),
+      ));
+      await tester.pump();
+
+      expect(find.text('Never backed up'), findsOneWidget);
+    });
+
+    // ---- T-187.W2 Previous backup timestamp ----------------------------------
+
+    testWidgets('T-187.W2 previous backup shows formatted timestamp',
+        (tester) async {
+      // Use a known epoch in 2025 (Jan 16 local time).
+      // Exact local format varies; we verify a non-"Never backed up" label.
+      const epoch = 1737034200; // 2025-01-16 (local)
+      await tester.pumpWidget(_buildApp(
+        initialState: BackupIdleState(lastBackupAt: epoch),
+      ));
+      await tester.pump();
+
+      expect(find.text('Never backed up'), findsNothing);
+      // A formatted date string should appear; check "Jan" or a digit pattern.
+      expect(find.textContaining('Jan'), findsOneWidget);
+    });
+
+    // ---- T-187.W3 In-progress state ------------------------------------------
+
+    testWidgets('T-187.W3 in-progress state shows CircularProgressIndicator',
+        (tester) async {
+      await tester.pumpWidget(_buildApp(
+        initialState: BackupInProgressState(),
+      ));
+      await tester.pump();
+
+      expect(find.byType(CircularProgressIndicator), findsWidgets);
+      expect(find.text('Creating backup…'), findsOneWidget);
+    });
+
+    // ---- T-187.W7 Backup Now button ------------------------------------------
+
+    testWidgets('T-187.W7 Backup Now button visible when idle', (tester) async {
+      await tester.pumpWidget(_buildApp(
+        initialState: BackupIdleState(),
+      ));
+      await tester.pump();
+
+      expect(find.text('Backup Now'), findsOneWidget);
+    });
+
+    // ---- T-187.W4 Success SnackBar -------------------------------------------
+
+    testWidgets('T-187.W4 success state triggers SnackBar with file path',
+        (tester) async {
+      final notifier = _FakeBackupNotifier(BackupIdleState());
+      await tester.pumpWidget(_buildApp(
+        initialState: BackupIdleState(),
+        notifier: notifier,
+      ));
+      await tester.pump();
+
+      // Drive to success state.
+      notifier.driveState(BackupDoneState('/data/backup.zip'));
+      await tester.pump();
+      await tester.pump(const Duration(milliseconds: 500));
+
+      expect(find.textContaining('/data/backup.zip'), findsOneWidget);
+    });
+
+    // ---- T-187.W5 Error SnackBar ---------------------------------------------
+
+    testWidgets('T-187.W5 error state triggers SnackBar with error message',
+        (tester) async {
+      final notifier = _FakeBackupNotifier(BackupIdleState());
+      await tester.pumpWidget(_buildApp(
+        initialState: BackupIdleState(),
+        notifier: notifier,
+      ));
+      await tester.pump();
+
+      // Drive to error state.
+      notifier.driveState(BackupFailedState('Disk full'));
+      await tester.pump();
+      await tester.pump(const Duration(milliseconds: 500));
+
+      expect(find.textContaining('Disk full'), findsOneWidget);
+    });
+  });
+}

--- a/test/unit/domain/usecases/close_installment_plan_use_case_test.dart
+++ b/test/unit/domain/usecases/close_installment_plan_use_case_test.dart
@@ -1,0 +1,320 @@
+// test/unit/domain/usecases/close_installment_plan_use_case_test.dart
+//
+// Unit tests for CloseInstallmentPlanUseCase (T-144).
+//
+// Uses hand-written fake repositories — no database I/O.
+//
+// Test cases (T-144):
+//   T-144.1  no-final-payment path: pending occurrences cancelled, template archived
+//   T-144.2  updateTotalOnEarlyClose=true updates totalConfiguredMinor to newTotalMinor
+//   T-144.3  already-archived template → Err(BusinessRuleFailure)
+//   T-144.4  non-existent template → Err(NotFoundFailure)
+//   T-144.5  closeEarly repository failure → Err(DatabaseFailure) propagated
+//   T-144.6  archive template repository failure → Err propagated
+//   T-144.7  updateTotalOnEarlyClose=false leaves totalConfiguredMinor unchanged
+
+import 'package:flutter_test/flutter_test.dart';
+
+import 'package:variance/domain/core/failure.dart';
+import 'package:variance/domain/core/result.dart';
+import 'package:variance/domain/entities/installment_occurrence.dart';
+import 'package:variance/domain/entities/installment_plan.dart';
+import 'package:variance/domain/entities/recurring_template.dart';
+import 'package:variance/domain/repositories/i_installment_plan_repository.dart';
+import 'package:variance/domain/repositories/i_recurring_template_repository.dart';
+import 'package:variance/domain/usecases/installment/close_installment_plan_use_case.dart';
+
+// ---------------------------------------------------------------------------
+// Fake IInstallmentPlanRepository
+// ---------------------------------------------------------------------------
+
+class _FakeInstallmentPlanRepository implements IInstallmentPlanRepository {
+  _FakeInstallmentPlanRepository({
+    required this.plan,
+    this.failCloseEarly = false,
+  });
+
+  final InstallmentPlan? plan;
+  final bool failCloseEarly;
+
+  bool closeEarlyCalled = false;
+  InstallmentPlan? updatedPlan;
+
+  @override
+  Stream<List<InstallmentPlan>> watchAll() => const Stream.empty();
+
+  @override
+  Stream<InstallmentPlan?> watchById(String id) =>
+      Stream.value(plan?.templateId == id ? plan : null);
+
+  @override
+  Future<Result<InstallmentPlan>> createAtomic({
+    required RecurringTemplate template,
+    required InstallmentPlan plan,
+    required List<InstallmentOccurrence> occurrences,
+  }) async =>
+      Ok(plan);
+
+  @override
+  Future<Result<InstallmentPlan>> create(InstallmentPlan plan) async =>
+      Ok(plan);
+
+  @override
+  Future<Result<InstallmentPlan>> update(InstallmentPlan plan) async {
+    updatedPlan = plan;
+    return Ok(plan);
+  }
+
+  @override
+  Future<Result<void>> closeEarly(String id) async {
+    closeEarlyCalled = true;
+    if (failCloseEarly) {
+      return const Err(DatabaseFailure('Simulated close failure'));
+    }
+    return const Ok(null);
+  }
+}
+
+// ---------------------------------------------------------------------------
+// Fake IRecurringTemplateRepository
+// ---------------------------------------------------------------------------
+
+class _FakeRecurringTemplateRepository implements IRecurringTemplateRepository {
+  _FakeRecurringTemplateRepository({this.template, this.failUpdate = false});
+
+  final RecurringTemplate? template;
+  final bool failUpdate;
+
+  RecurringTemplate? updatedTemplate;
+
+  @override
+  Stream<List<RecurringTemplate>> watchAll() => const Stream.empty();
+
+  @override
+  Stream<RecurringTemplate?> watchById(String id) =>
+      Stream.value(template?.id == id ? template : null);
+
+  @override
+  Future<Result<RecurringTemplate>> create(RecurringTemplate t) async => Ok(t);
+
+  @override
+  Future<Result<RecurringTemplate>> update(RecurringTemplate t) async {
+    if (failUpdate) {
+      return const Err(DatabaseFailure('Simulated archive failure'));
+    }
+    updatedTemplate = t;
+    return Ok(t);
+  }
+
+  @override
+  Future<Result<void>> pause(String id, {required int pauseUntil}) async =>
+      const Ok(null);
+
+  @override
+  Future<Result<void>> resume(String id) async => const Ok(null);
+
+  @override
+  Future<Result<void>> softDelete(String id) async => const Ok(null);
+
+  @override
+  Future<Result<List<RecurringTemplate>>> getDue(DateTime asOf) async =>
+      const Ok([]);
+}
+
+// ---------------------------------------------------------------------------
+// Helpers
+// ---------------------------------------------------------------------------
+
+final _baseTemplate = RecurringTemplate(
+  id: 'tmpl-close-1',
+  transactionType: 'expense',
+  status: RecurringTemplateStatus.active,
+  amountMinor: 10000,
+  currencyCode: 'INR',
+  recurrenceN: 1,
+  recurrenceUnit: RecurrenceUnit.month,
+  startDate: 20000,
+  isInstallment: true,
+  createdAt: 1700000000,
+  updatedAt: 1700000000,
+);
+
+final _basePlan = InstallmentPlan(
+  templateId: 'tmpl-close-1',
+  totalConfiguredMinor: 120000,
+  numberOfInstallments: 12,
+  createdAt: 1700000000,
+);
+
+CloseInstallmentPlanUseCase _makeUseCase({
+  InstallmentPlan? plan,
+  RecurringTemplate? template,
+  bool failCloseEarly = false,
+  bool failUpdateTemplate = false,
+}) {
+  return CloseInstallmentPlanUseCase(
+    planRepository: _FakeInstallmentPlanRepository(
+      plan: plan ?? _basePlan,
+      failCloseEarly: failCloseEarly,
+    ),
+    templateRepository: _FakeRecurringTemplateRepository(
+      template: template ?? _baseTemplate,
+      failUpdate: failUpdateTemplate,
+    ),
+  );
+}
+
+// ---------------------------------------------------------------------------
+// Tests
+// ---------------------------------------------------------------------------
+
+void main() {
+  group('CloseInstallmentPlanUseCase', () {
+    // ---- T-144.1 No-final-payment path ---------------------------------------
+
+    test('T-144.1 no-final-payment: closeEarly called, template archived',
+        () async {
+      final planRepo = _FakeInstallmentPlanRepository(plan: _basePlan);
+      final templateRepo = _FakeRecurringTemplateRepository(
+        template: _baseTemplate,
+      );
+      final useCase = CloseInstallmentPlanUseCase(
+        planRepository: planRepo,
+        templateRepository: templateRepo,
+      );
+
+      final result = await useCase(
+        const CloseInstallmentPlanInput(id: 'tmpl-close-1'),
+      );
+
+      expect(result, isA<Ok<void>>());
+      expect(planRepo.closeEarlyCalled, isTrue);
+      expect(
+        templateRepo.updatedTemplate?.status,
+        RecurringTemplateStatus.archived,
+      );
+      expect(
+        templateRepo.updatedTemplate?.archivedReason,
+        ArchivedReason.earlyClose,
+      );
+    });
+
+    // ---- T-144.2 updateTotalOnEarlyClose = true ------------------------------
+
+    test('T-144.2 updateTotalOnEarlyClose=true sets totalConfiguredMinor',
+        () async {
+      final planRepo = _FakeInstallmentPlanRepository(plan: _basePlan);
+      final templateRepo = _FakeRecurringTemplateRepository(
+        template: _baseTemplate,
+      );
+      final useCase = CloseInstallmentPlanUseCase(
+        planRepository: planRepo,
+        templateRepository: templateRepo,
+      );
+
+      final result = await useCase(
+        const CloseInstallmentPlanInput(
+          id: 'tmpl-close-1',
+          updateTotalOnEarlyClose: true,
+          newTotalMinor: 75000,
+        ),
+      );
+
+      expect(result, isA<Ok<void>>());
+      // Plan's totalConfiguredMinor must be updated to 75000.
+      expect(planRepo.updatedPlan?.totalConfiguredMinor, 75000);
+    });
+
+    // ---- T-144.3 Already archived → BusinessRuleFailure ----------------------
+
+    test('T-144.3 already-archived template → Err(BusinessRuleFailure)',
+        () async {
+      final archivedTemplate = _baseTemplate.copyWith(
+        status: RecurringTemplateStatus.archived,
+        archivedAt: 1700000000,
+        archivedReason: ArchivedReason.earlyClose,
+      );
+      final useCase = _makeUseCase(template: archivedTemplate);
+
+      final result = await useCase(
+        const CloseInstallmentPlanInput(id: 'tmpl-close-1'),
+      );
+
+      expect(result, isA<Err<void>>());
+      final failure = (result as Err<void>).failure;
+      expect(failure, isA<BusinessRuleFailure>());
+    });
+
+    // ---- T-144.4 Non-existent template → NotFoundFailure ---------------------
+
+    test('T-144.4 non-existent template → Err(NotFoundFailure)', () async {
+      // templateRepo returns null for 'tmpl-not-found'.
+      final planRepo = _FakeInstallmentPlanRepository(plan: null);
+      final templateRepo = _FakeRecurringTemplateRepository(template: null);
+      final useCase = CloseInstallmentPlanUseCase(
+        planRepository: planRepo,
+        templateRepository: templateRepo,
+      );
+
+      final result = await useCase(
+        const CloseInstallmentPlanInput(id: 'tmpl-not-found'),
+      );
+
+      expect(result, isA<Err<void>>());
+      expect((result as Err<void>).failure, isA<NotFoundFailure>());
+    });
+
+    // ---- T-144.5 closeEarly failure → DatabaseFailure propagated -------------
+
+    test('T-144.5 closeEarly failure → Err(DatabaseFailure) propagated',
+        () async {
+      final useCase = _makeUseCase(failCloseEarly: true);
+
+      final result = await useCase(
+        const CloseInstallmentPlanInput(id: 'tmpl-close-1'),
+      );
+
+      expect(result, isA<Err<void>>());
+      expect((result as Err<void>).failure, isA<DatabaseFailure>());
+    });
+
+    // ---- T-144.6 Archive template failure propagated -------------------------
+
+    test('T-144.6 archive template failure propagated', () async {
+      final useCase = _makeUseCase(failUpdateTemplate: true);
+
+      final result = await useCase(
+        const CloseInstallmentPlanInput(id: 'tmpl-close-1'),
+      );
+
+      expect(result, isA<Err<void>>());
+      expect((result as Err<void>).failure, isA<DatabaseFailure>());
+    });
+
+    // ---- T-144.7 updateTotalOnEarlyClose=false leaves total unchanged --------
+
+    test(
+        'T-144.7 updateTotalOnEarlyClose=false leaves totalConfiguredMinor unchanged',
+        () async {
+      final planRepo = _FakeInstallmentPlanRepository(plan: _basePlan);
+      final templateRepo = _FakeRecurringTemplateRepository(
+        template: _baseTemplate,
+      );
+      final useCase = CloseInstallmentPlanUseCase(
+        planRepository: planRepo,
+        templateRepository: templateRepo,
+      );
+
+      final result = await useCase(
+        const CloseInstallmentPlanInput(
+          id: 'tmpl-close-1',
+          updateTotalOnEarlyClose: false,
+        ),
+      );
+
+      expect(result, isA<Ok<void>>());
+      // Plan.update must NOT have been called.
+      expect(planRepo.updatedPlan, isNull);
+    });
+  });
+}


### PR DESCRIPTION
## Summary

- **T-186**: Resolves OQ-SDS-SC-001 — adds Android backup exclusion rules to prevent flutter_secure_storage PIN data from appearing in device backups
- **T-187**: Builds BackupDataScreen at `/settings/backup` with SAF file picker, last-backup timestamp display, in-progress indicator, and success/error snackbars
- **T-188**: Implements BackupService ZIP export engine — consistent DB snapshot, manifest.json, variance_export.json, photo bundling, missing-file skip
- **T-144**: Implements CloseInstallmentPlanUseCase (was stubbed) with full unit-test coverage

## Changes

- `android/app/src/main/AndroidManifest.xml` — adds `allowBackup`, `dataExtractionRules`, `fullBackupContent` attributes
- `android/app/src/main/res/xml/backup_rules.xml` — API 23–30 backup exclusion (flutter_secure_storage)
- `android/app/src/main/res/xml/data_extraction_rules.xml` — API 31+ backup exclusion (cloud + device-transfer)
- `lib/domain/entities/app_settings.dart` — adds `lastBackupAt` field
- `lib/domain/repositories/i_app_settings_repository.dart` — adds `lastBackupAt` to `AppSettingsPatch`
- `lib/data/repositories/app_settings_repository_impl.dart` — wires `last_backup_at` KV key
- `lib/infrastructure/backup/backup_service.dart` — ZIP export engine with injectable version resolver
- `lib/presentation/features/settings/backup/backup_providers.dart` — BackupNotifier + BackupState sealed hierarchy
- `lib/presentation/features/settings/backup/backup_data_screen.dart` — BackupDataScreen widget
- `lib/presentation/navigation/app_router.dart` — replaces placeholder `/settings/backup` route
- `lib/domain/usecases/installment/close_installment_plan_use_case.dart` — full implementation replacing stub
- `pubspec.yaml` — adds `archive ^4.0.9`, `package_info_plus ^8.x`

## Tests

- `test/infrastructure/backup/backup_service_test.dart` — 6 tests: manifest structure, soft-delete exclusion, missing photo skip, non-deleted entities included, ZIP structure, file name pattern
- `test/presentation/features/settings/backup/backup_data_screen_test.dart` — 7 widget tests: idle/progress/success/error states, snackbar messages, timestamp display
- `test/unit/domain/usecases/close_installment_plan_use_case_test.dart` — 7 unit tests: all paths (no-final-payment, update total, archived guard, not-found, DB failures)

## Checklist

- [x] `flutter analyze` — no errors
- [x] `flutter test` — all 820 tests pass
- [x] `dart format` applied to all changed files
- [x] No golden test regressions (no design-critical widget changed)
- [x] OQ-SDS-SC-001 resolved: secure storage excluded from both API 31+ and API 23-30 backup paths

🤖 Generated with [Claude Code](https://claude.com/claude-code)